### PR TITLE
    1. fix: emr_ids_coverage, emr_ids and emr_track.unique did not work

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -435,7 +435,9 @@ emr_ids_vals_coverage <- function(ids, tracks, stime = NULL, etime = NULL, filte
                 etime = etime
             )
             res$track <- track
-            res <- res %>% dplyr::filter(val %in% ltrack$values)
+            if (!is.null(ltrack$values)) {
+                res <- res %>% dplyr::filter(val %in% ltrack$values)
+            }
             return(res)
         })
     }

--- a/R/filter.R
+++ b/R/filter.R
@@ -293,7 +293,6 @@ emr_filter.create_from_name <- function(filter) {
 #' emr_filter.create("f1", "dense_track", time.shift = c(2, 4))
 #' emr_filter.create("f2", "dense_track", keepref = TRUE)
 #' emr_extract("sparse_track", filter = "!f1 & f2")
-#' 
 #' @export emr_filter.create
 emr_filter.create <- function(filter, src, keepref = F, time.shift = NULL, val = NULL, expiration = NULL, operator = "=") {
     if (missing(filter) || missing(src)) {

--- a/R/track.R
+++ b/R/track.R
@@ -765,7 +765,11 @@ emr_track.percentile <- function(track, val, lower = TRUE) {
     .emr_checkroot()
 
     if (emr_track.logical.exists(track)) {
-        stop(sprintf("Track %s is categorical: percentile queries are not supported", track))
+        ltrack <- emr_track.logical.info(track)
+        if (!is.null(ltrack$values) || emr_track.info(ltrack$source)$categorical) {
+            stop(sprintf("Track %s is categorical: percentile queries are not supported", track))
+        }
+        track <- ltrack$source
     }
 
     .emr_call("emr_track_percentile", track, val, lower, new.env(parent = parent.frame()))

--- a/man/emr_filter.create.Rd
+++ b/man/emr_filter.create.Rd
@@ -72,7 +72,6 @@ emr_db.init_examples()
 emr_filter.create("f1", "dense_track", time.shift = c(2, 4))
 emr_filter.create("f2", "dense_track", keepref = TRUE)
 emr_extract("sparse_track", filter = "!f1 & f2")
-
 }
 \seealso{
 \code{\link{emr_filter.attr.src}}, \code{\link{emr_filter.ls}},

--- a/src/NRTrack.cpp
+++ b/src/NRTrack.cpp
@@ -222,9 +222,13 @@ SEXP emr_track_ids(SEXP _track, SEXP _envir)
 
         if (logical_track){
             track = g_db->track(logical_track->source.c_str());
-            unordered_set<double> vals(logical_track->values.begin(),
-                                       logical_track->values.end());            
-            track->ids(ids, vals);
+            if (logical_track->has_values()){
+                unordered_set<double> vals(logical_track->values.begin(),
+                                           logical_track->values.end());
+                track->ids(ids, vals);
+            } else {
+                track->ids(ids);
+            }                
         } else {
             track->ids(ids);
         }


### PR DESCRIPTION
    on logical tracks without values.
    2. fix: allow emr_percentile on numeric logical track