### PR TITLE
Refactor file locking to use atomic rename pattern to fix NFS stalls

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,3 +19,5 @@
 ^docs$
 ^naryndb/$
 ^naryndb$
+^dev$
+^AGENTS.md$

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ sample_db/
 vignettes/articles/sample_db
 vignettes/sample_db
 naryndb/
+dev/
+AGENTS.md

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: naryn
 Title: Native Access Medical Record Retriever for High Yield Analytics
-Version: 2.6.31
+Version: 2.7.0
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naryn 2.7.0
+
+* **breaking change**: Use a new locking mechanism for the database files. Please do not use old and new versions of the package in the same database.
+
 # naryn 2.6.31 
 
 * Removed non-API calls to `Rf_GetOption` in the C++ code.

--- a/src/BufferedFile.cpp
+++ b/src/BufferedFile.cpp
@@ -97,6 +97,9 @@ int BufferedFile::close()
                 unlink(m_temp_filename.c_str());
             }
             m_temp_filename.clear();
+            // Report the file callers actually asked for, not the staging name, in any error
+            // message raised after this point.
+            m_filename = m_real_filename;
         }
 
 		m_eof = true;

--- a/src/BufferedFile.cpp
+++ b/src/BufferedFile.cpp
@@ -1,5 +1,6 @@
 #include <fcntl.h>
 #include <string.h>
+#include <limits.h>
 #include "BufferedFile.h"
 #include "TGLException.h"
 
@@ -12,13 +13,26 @@ int64_t BufferedFile::file_size(const char *path)
 	return (int64_t)st.st_size;
 }
 
-int BufferedFile::open(const char *path, const char *mode, bool lock){
-	close();
-	m_filename = (string)path;
-	m_fp = fopen(path, mode);
+int BufferedFile::open(const char *path, const char *mode, bool lock, bool atomic) {
+    close(); // Close existing
+    m_real_filename = (string)path;
+    m_is_atomic = atomic;
+
+    if (m_is_atomic && (strcmp(mode, "w") == 0 || strcmp(mode, "wb") == 0)) {
+        // Create a unique temp file: filename.tmp.PID
+        char buf[PATH_MAX];
+        snprintf(buf, sizeof(buf), "%s.tmp.%d", path, getpid());
+        m_temp_filename = buf;
+        m_filename = m_temp_filename; // Parent class uses m_filename
+    } else {
+        m_filename = m_real_filename;
+        m_temp_filename.clear();
+    }
+
+    m_fp = fopen(m_filename.c_str(), mode);
 
 	if (m_fp) {
-        if (lock) {
+        if (lock && !m_is_atomic) {
             struct flock fl;
 
             // according to fcntl() manual, lock is automatically released when the file description is closed
@@ -49,6 +63,16 @@ int BufferedFile::close()
 	if (m_fp) {
 		int retv = fclose(m_fp);
 		m_fp = NULL;
+        
+        // ATOMIC COMMIT
+        if (m_is_atomic && !m_temp_filename.empty() && retv == 0) {
+            if (rename(m_temp_filename.c_str(), m_real_filename.c_str()) != 0) {
+                // Log error or handle failure
+                unlink(m_temp_filename.c_str()); // Cleanup
+                return -1;
+            }
+        }
+
 		m_eof = true;
 		m_phys_pos = -1;
 		return retv;

--- a/src/BufferedFile.cpp
+++ b/src/BufferedFile.cpp
@@ -97,9 +97,6 @@ int BufferedFile::close()
                 unlink(m_temp_filename.c_str());
             }
             m_temp_filename.clear();
-            // Report the file callers actually asked for, not the staging name, in any error
-            // message raised after this point.
-            m_filename = m_real_filename;
         }
 
 		m_eof = true;

--- a/src/BufferedFile.cpp
+++ b/src/BufferedFile.cpp
@@ -1,6 +1,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <limits.h>
+#include <unistd.h>
 #include "BufferedFile.h"
 #include "TGLException.h"
 
@@ -15,13 +16,18 @@ int64_t BufferedFile::file_size(const char *path)
 
 int BufferedFile::open(const char *path, const char *mode, bool lock, bool atomic) {
     close(); // Close existing
-    m_real_filename = (string)path;
+    m_real_filename = std::string(path);
     m_is_atomic = atomic;
 
     if (m_is_atomic && (strcmp(mode, "w") == 0 || strcmp(mode, "wb") == 0)) {
         // Create a unique temp file: filename.tmp.PID
         char buf[PATH_MAX];
-        snprintf(buf, sizeof(buf), "%s.tmp.%d", path, getpid());
+        char host[64] = "unknown";
+        if (gethostname(host, sizeof(host)) != 0) {
+            strncpy(host, "unknown", sizeof(host));
+        }
+        host[sizeof(host) - 1] = '\0';
+        snprintf(buf, sizeof(buf), "%s.tmp.%s.%d", path, host, getpid());
         m_temp_filename = buf;
         m_filename = m_temp_filename; // Parent class uses m_filename
     } else {
@@ -58,6 +64,22 @@ int BufferedFile::open(const char *path, const char *mode, bool lock, bool atomi
 	return -1;
 }
 
+void BufferedFile::discard()
+{
+    if (m_fp) {
+        fclose(m_fp);
+        m_fp = NULL;
+    }
+
+    if (m_is_atomic && !m_temp_filename.empty()) {
+        unlink(m_temp_filename.c_str());
+        m_temp_filename.clear();
+    }
+
+    m_eof = true;
+    m_phys_pos = -1;
+}
+
 int BufferedFile::close()
 {
 	if (m_fp) {
@@ -65,12 +87,16 @@ int BufferedFile::close()
 		m_fp = NULL;
         
         // ATOMIC COMMIT
-        if (m_is_atomic && !m_temp_filename.empty() && retv == 0) {
-            if (rename(m_temp_filename.c_str(), m_real_filename.c_str()) != 0) {
-                // Log error or handle failure
-                unlink(m_temp_filename.c_str()); // Cleanup
-                return -1;
+        if (m_is_atomic && !m_temp_filename.empty()) {
+            if (retv == 0) {
+                if (rename(m_temp_filename.c_str(), m_real_filename.c_str()) != 0) {
+                    unlink(m_temp_filename.c_str());
+                    retv = -1;
+                }
+            } else {
+                unlink(m_temp_filename.c_str());
             }
+            m_temp_filename.clear();
         }
 
 		m_eof = true;

--- a/src/BufferedFile.h
+++ b/src/BufferedFile.h
@@ -25,7 +25,7 @@ public:
 	// returns 0 on success, -1 on failure.
     // if lock is true, fcntl lock is acquired according to the mode (see: fcntl, F_SETLKW);
     // file is unlocked on close() or destructor.
-	int open(const char *path, const char *mode, bool lock = false);
+	int open(const char *path, const char *mode, bool lock = false, bool atomic = false);
 
 	// see fclose for return value
 	int close();
@@ -67,6 +67,9 @@ protected:
 	FILE       *m_fp{NULL};
 	int         m_eof;
 	std::string m_filename;
+    std::string m_real_filename;
+    std::string m_temp_filename;
+    bool        m_is_atomic{false};
 	char       *m_buf{NULL};
 	unsigned    m_bufsize;
 	int64_t     m_file_size;

--- a/src/BufferedFile.h
+++ b/src/BufferedFile.h
@@ -53,7 +53,9 @@ public:
 
 	bool opened() const { return m_fp != NULL; }
 
-	const std::string &file_name() const { return m_filename; }
+	// The file the caller asked for. On an atomic write that is the destination, not the staging
+	// path - error messages naming a .tmp.<host>.<pid> file help nobody.
+	const std::string &file_name() const { return m_is_atomic ? m_real_filename : m_filename; }
 
 	int64_t file_size() const { return m_file_size; }
 

--- a/src/BufferedFile.h
+++ b/src/BufferedFile.h
@@ -29,6 +29,8 @@ public:
 
 	// see fclose for return value
 	int close();
+    // close without committing an atomic rename
+    void discard();
 
 	// see fgetc for return value
 	int getc();

--- a/src/EMRDb.cpp
+++ b/src/EMRDb.cpp
@@ -332,8 +332,10 @@ void EMRDb::update_logical_tracks_file() {
             verror("Error while writing file %s: %s\n", bf.file_name().c_str(),
                    strerror(errno));
 
-        // release lock
-        bf.close();
+        // close() commits the staged file with a rename. If that fails the update is thrown
+        // away and the old file stays, so it has to be reported like any other write error.
+        if (bf.close())
+            verror("Failed to commit file %s: %s", filename.c_str(), strerror(errno));
     }
     catch (...) {
         bf.discard();
@@ -755,12 +757,36 @@ int EMRDb::get_db_idx(const string& db_id) {
     
 }
 
-// Helper to acquire a persistent lock file for writing
+// Helper to acquire a persistent lock file for writing.
+//
+// Reentrancy matters here, and not for style reasons: fcntl locks are per (process, file), not
+// per fd, and closing ANY fd on a locked file drops every lock the process holds on it. So a
+// nested acquire/release of the same path - load_track() holds the track list lock and calls
+// load_track_list(), which on a missing or corrupt list calls create_track_list_file(), which
+// locks the same path - would silently release the outer lock at the inner release, leaving the
+// rest of the outer critical section unprotected. We therefore hand the nested caller -1
+// ("someone above you already holds this") and let release_writer_lock ignore it; every call
+// site already treats -1 as "nothing to release".
 int EMRDb::acquire_writer_lock(const string &base_filename) {
     string lock_path = base_filename + ".lock";
-    
-    // Open/Create the lock file
-    int fd = open(lock_path.c_str(), O_RDWR | O_CREAT, 0666);
+
+    if (m_held_lock_paths.find(lock_path) != m_held_lock_paths.end()) {
+        return -1; // already held further up this call stack
+    }
+
+    // The db can be written by more than one uid (a shared/curated db plus per-user dbs), so the
+    // lock file must be writable by all of them. The mode passed to open() is masked by umask,
+    // which would typically leave it 0644 and owned by whoever happened to create it first -
+    // every other user then fails to open it O_RDWR. Create it exclusively and fchmod past the
+    // umask; if it already exists, just open it.
+    int fd = open(lock_path.c_str(), O_RDWR | O_CREAT | O_EXCL, 0666);
+    if (fd != -1) {
+        if (fchmod(fd, 0666) == -1) {
+            vdebug("Failed to chmod lock file %s: %s", lock_path.c_str(), strerror(errno));
+        }
+    } else if (errno == EEXIST) {
+        fd = open(lock_path.c_str(), O_RDWR);
+    }
     if (fd == -1) {
          verror("Failed to open lock file %s: %s", lock_path.c_str(), strerror(errno));
     }
@@ -768,7 +794,7 @@ int EMRDb::acquire_writer_lock(const string &base_filename) {
     struct flock fl;
     memset(&fl, 0, sizeof(fl));
     fl.l_type = F_WRLCK; // Exclusive Write Lock
-    
+
     // Blocking wait for lock
     while (fcntl(fd, F_SETLKW, &fl) == -1) {
         if (errno != EINTR) {
@@ -776,14 +802,23 @@ int EMRDb::acquire_writer_lock(const string &base_filename) {
             verror("Failed to lock %s: %s", lock_path.c_str(), strerror(errno));
         }
     }
-    
+
+    m_held_lock_paths.insert(lock_path);
+    m_held_lock_fds[fd] = lock_path;
     return fd;
 }
 
 void EMRDb::release_writer_lock(int fd) {
-    if (fd != -1) {
-        close(fd); // Closing fd releases the fcntl lock automatically
+    if (fd == -1) {
+        return; // nested acquire: the outer holder owns the lock and will release it
     }
+
+    auto ifd = m_held_lock_fds.find(fd);
+    if (ifd != m_held_lock_fds.end()) {
+        m_held_lock_paths.erase(ifd->second);
+        m_held_lock_fds.erase(ifd);
+    }
+    close(fd); // Closing fd releases the fcntl lock automatically
 }
 
 void EMRDb::validate_rootdirs(const vector<string>& rootdirs){
@@ -1000,7 +1035,9 @@ void EMRDb::create_track_list_file(string db_id, BufferedFile *_pbf) {
         // write the results into track list file
         update_track_list_file(track_list, db_id, *pbf);
 
-        if (!_pbf) pbf->close();
+        if (!_pbf && pbf->close())
+            verror("Failed to commit file %s: %s",
+                   track_list_filename(db_id).c_str(), strerror(errno));
     }
     catch (...) {
         if (dir){
@@ -1274,7 +1311,9 @@ void EMRDb::load_track(const char *track_name, const string& db_id){
              verror("Failed to open file %s: %s", track_list_filename(db_id).c_str(), strerror(errno));
         }
         update_track_list_file(m_tracks, db_id, bf);
-        bf.close();
+        if (bf.close())
+            verror("Failed to commit file %s: %s",
+                   track_list_filename(db_id).c_str(), strerror(errno));
     }
     catch (...) {
         bf.discard();
@@ -1347,7 +1386,9 @@ void EMRDb::unload_track(const char *track_name, const bool& overridden, const b
                  verror("Failed to open file %s: %s", track_list_filename(db_id).c_str(), strerror(errno));
             }
             update_track_list_file(m_tracks, db_id, bf);
-            bf.close();
+            if (bf.close())
+                verror("Failed to commit file %s: %s",
+                       track_list_filename(db_id).c_str(), strerror(errno));
         }
     }
     catch (...) {
@@ -1427,30 +1468,42 @@ void EMRDb::set_track_attr(const char *trackname, const char *attr,
         track_attrs_fname = track_attrs_filename(db_id, trackname);
     }
     
-    TrackAttrs track_attrs = EMRTrack::load_attrs(trackname, track_attrs_fname.c_str());
+    // Setting one attribute is a read-modify-write of the whole per-track attrs file, so it
+    // needs the writer lock even though save_attrs itself is atomic: without it two concurrent
+    // setters both read the old set and the second one's write drops the first one's attribute.
+    int lock_fd = acquire_writer_lock(track_attrs_fname);
 
-    if (val) {
-        track_attrs[attr] = val;
+    try {
+        TrackAttrs track_attrs = EMRTrack::load_attrs(trackname, track_attrs_fname.c_str());
+
+        if (val) {
+            track_attrs[attr] = val;
+        }
+        else {
+            track_attrs.erase(attr);
+        }
+
+        EMRTrack::save_attrs(trackname, track_attrs_fname.c_str(), track_attrs);
+
+        load_tracks_attrs(db_id);
+
+        if (track_attrs.empty()){
+            m_track2attrs[db_id].erase(trackname);
+        }
+        else {
+            m_track2attrs[db_id][trackname] = track_attrs;
+        }
     }
-    else {
-        track_attrs.erase(attr);
-    }    
-
-    EMRTrack::save_attrs(trackname, track_attrs_fname.c_str(), track_attrs);
-
-    load_tracks_attrs(db_id);
-
-    if (track_attrs.empty()){
-        m_track2attrs[db_id].erase(trackname);
+    catch (...) {
+        release_writer_lock(lock_fd);
+        throw;
     }
-    else {
-        m_track2attrs[db_id][trackname] = track_attrs;
-    }
+    release_writer_lock(lock_fd);
 
     if (update){
         update_tracks_attrs_file(db_id);
     }
-    
+
 }
 
 void EMRDb::load_tracks_attrs(string db_id)
@@ -1632,9 +1685,11 @@ void EMRDb::update_tracks_attrs_file(string db_id) {
         if (bf.error()){
             verror("Error while writing file %s: %s\n", bf.file_name().c_str(), strerror(errno));
         }
-        bf.close();
+        if (bf.close())
+            verror("Failed to commit file %s: %s", filename.c_str(), strerror(errno));
     }
     catch (...) {
+        bf.discard();
         release_writer_lock(lock_fd);
         throw;
     }

--- a/src/EMRDb.cpp
+++ b/src/EMRDb.cpp
@@ -164,22 +164,6 @@ void EMRDb::cache_tracks() {
 #endif
 }
 
-void EMRDb::lock_logical_track_list(BufferedFile &lock, const char *mode) {
-    vdebug("MODE: %s", mode);
-    if (!lock.opened()) {
-        string filename = logical_tracks_filename();
-        if (lock.open(filename.c_str(), mode, true))
-            verror("Failed to open file %s: %s", filename.c_str(),
-                   strerror(errno));
-        if (!strcmp(mode, "r"))
-            vdebug("R lock acquired for logical tracks file\n");
-        else if (!strcmp(mode, "w"))
-            vdebug("W lock acquired for logical tracks file\n");
-        else
-            vdebug("R/W lock acquired for logical tracks file\n");
-    }
-}
-
 void EMRDb::load_logical_tracks_from_disk() {
     DIR *dir = NULL;
 
@@ -314,42 +298,48 @@ void EMRDb::remove_logical_track(const char *track_name, const bool &update) {
 void EMRDb::update_logical_tracks_file() {
     BufferedFile bf;
     string filename = logical_tracks_filename();
+    int lock_fd = acquire_writer_lock(filename);
 
-    lock_logical_track_list(bf, "w");
-
-    vdebug("Creating %s with %lu logical tracks", filename.c_str(),
-           m_logical_tracks.size());
-    if (bf.open(filename.c_str(), "w"))
-    {
-        verror("Failed to open file %s: %s", filename.c_str(), strerror(errno));
-    }
-
-    for (auto const &ltracks : m_logical_tracks)
-    {
-        bf.write(ltracks.first.c_str(),
-                 ltracks.first.size() + 1); // track name
-
-        bf.write(ltracks.second.source.c_str(),
-                 ltracks.second.source.size() + 1); // source track
-
-        uint32_t num_values =
-            (uint32_t)ltracks.second.values.size(); // number of attributes
-
-        bf.write(&num_values, sizeof(num_values));
-        if (!ltracks.second.values.empty())
+    try {
+        vdebug("Creating %s with %lu logical tracks", filename.c_str(),
+               m_logical_tracks.size());
+        if (bf.open(filename.c_str(), "w", false, true))
         {
-            bf.write(
-                ltracks.second.values.data(),
-                sizeof(int) * ltracks.second.values.size());
+            verror("Failed to open file %s: %s", filename.c_str(), strerror(errno));
         }
+
+        for (auto const &ltracks : m_logical_tracks)
+        {
+            bf.write(ltracks.first.c_str(),
+                     ltracks.first.size() + 1); // track name
+
+            bf.write(ltracks.second.source.c_str(),
+                     ltracks.second.source.size() + 1); // source track
+
+            uint32_t num_values =
+                (uint32_t)ltracks.second.values.size(); // number of attributes
+
+            bf.write(&num_values, sizeof(num_values));
+            if (!ltracks.second.values.empty())
+            {
+                bf.write(
+                    ltracks.second.values.data(),
+                    sizeof(int) * ltracks.second.values.size());
+            }
+        }
+
+        if (bf.error())
+            verror("Error while writing file %s: %s\n", bf.file_name().c_str(),
+                   strerror(errno));
+
+        // release lock
+        bf.close();
     }
-
-    if (bf.error())
-        verror("Error while writing file %s: %s\n", bf.file_name().c_str(),
-               strerror(errno));
-
-    // release lock
-    bf.close();
+    catch (...) {
+        release_writer_lock(lock_fd);
+        throw;
+    }
+    release_writer_lock(lock_fd);
 }
 
 void EMRDb::clear_logical_tracks() {
@@ -365,7 +355,7 @@ void EMRDb::load_logical_tracks() {
     BufferedFile bf;
     string filename = logical_tracks_filename();
     // we open the file and lock it
-    if (bf.open(filename.c_str(), "r", true))
+    if (bf.open(filename.c_str(), "r"))
     {
         if (errno != ENOENT)
         {
@@ -764,6 +754,37 @@ int EMRDb::get_db_idx(const string& db_id) {
     
 }
 
+// Helper to acquire a persistent lock file for writing
+int EMRDb::acquire_writer_lock(const string &base_filename) {
+    string lock_path = base_filename + ".lock";
+    
+    // Open/Create the lock file
+    int fd = open(lock_path.c_str(), O_RDWR | O_CREAT, 0666);
+    if (fd == -1) {
+         verror("Failed to open lock file %s: %s", lock_path.c_str(), strerror(errno));
+    }
+
+    struct flock fl;
+    memset(&fl, 0, sizeof(fl));
+    fl.l_type = F_WRLCK; // Exclusive Write Lock
+    
+    // Blocking wait for lock
+    while (fcntl(fd, F_SETLKW, &fl) == -1) {
+        if (errno != EINTR) {
+            close(fd);
+            verror("Failed to lock %s: %s", lock_path.c_str(), strerror(errno));
+        }
+    }
+    
+    return fd;
+}
+
+void EMRDb::release_writer_lock(int fd) {
+    if (fd != -1) {
+        close(fd); // Closing fd releases the fcntl lock automatically
+    }
+}
+
 void EMRDb::validate_rootdirs(const vector<string>& rootdirs){
     struct stat fs;
     int fd1 = -1;
@@ -908,7 +929,7 @@ void EMRDb::reload() {
 
     for (auto db_id = m_rootdirs.begin(); db_id != m_rootdirs.end(); db_id++){
         create_track_list_file(*db_id, NULL);
-        create_tracks_attrs_file(*db_id, false);
+        create_tracks_attrs_file(*db_id);
     }
 
     load_logical_tracks_from_disk();
@@ -916,40 +937,15 @@ void EMRDb::reload() {
     refresh();
 }
 
-void EMRDb::lock_track_lists(vector<BufferedFile> &locks, const char *mode) {
-    for (int db_idx = 0; db_idx < (int)m_rootdirs.size(); db_idx++) {
-        lock_track_list(m_rootdirs[db_idx], locks[db_idx], mode);
-    }
-}
-
-void EMRDb::lock_track_list(string db_id, BufferedFile &lock, const char *mode){
-
-    vdebug("MODE: %s", mode);
-
-    if (!lock.opened()) {
-
-        string filename = track_list_filename(db_id);
-
-        if (lock.open(filename.c_str(), mode, true))
-            verror("Failed to open file %s: %s", filename.c_str(),
-                   strerror(errno));
-
-        if (!strcmp(mode, "r"))
-            vdebug("R lock acquired\n");
-
-        else if (!strcmp(mode, "w"))
-            vdebug("W lock acquired\n");
-
-        else
-            vdebug("R/W lock acquired\n");
-    }
-}
-
-
 void EMRDb::create_track_list_file(string db_id, BufferedFile *_pbf) {
     DIR *dir = NULL;
+    int lock_fd = -1;
 
     vdebug("Rescanning %s dir to acquire list of tracks", db_id.c_str());
+
+    if (!_pbf) {
+        lock_fd = acquire_writer_lock(track_list_filename(db_id));
+    }
 
     try {
         BufferedFile bf;
@@ -957,10 +953,11 @@ void EMRDb::create_track_list_file(string db_id, BufferedFile *_pbf) {
 
         if (!_pbf) {
             vdebug("Opening %s track list for write", db_id.c_str());
-            // Lock the file for writing before scan to prevent concurrent scan
-            // at the same time. If not done, an earlier scan might write its
-            // results to track list file after a later scan.
-            lock_track_list(db_id, bf, "w");
+            string filename = track_list_filename(db_id);
+            if (pbf->open(filename.c_str(), "w", false, true)) {
+                verror("Failed to open file %s: %s", filename.c_str(),
+                       strerror(errno));
+            }
         }
 
         // scan directory structure
@@ -1002,13 +999,18 @@ void EMRDb::create_track_list_file(string db_id, BufferedFile *_pbf) {
 
         // write the results into track list file
         update_track_list_file(track_list, db_id, *pbf);
+
+        if (!_pbf) pbf->close();
     }
     catch (...) {
         if (dir){
             closedir(dir);
         }
+        if (lock_fd != -1) release_writer_lock(lock_fd);
         throw;
     }
+
+    if (lock_fd != -1) release_writer_lock(lock_fd);
 }
 
 void EMRDb::update_track_list_file(const Name2Track &tracks, string db_id, BufferedFile &bf) {
@@ -1043,12 +1045,6 @@ void EMRDb::update_track_list_file(const Name2Track &tracks, string db_id, Buffe
     bf.truncate(); // file might be open for update and not just for write
 }
 
-void EMRDb::load_track_list(string db_id, BufferedFile &bf, bool force) {
-    vdebug("Loading %s track list before update\n", db_id.c_str());
-    lock_track_list(db_id, bf, "r+");
-    load_track_list(db_id, &bf, force);
-}
-
 void EMRDb::load_track_list(string db_id, BufferedFile *_pbf, bool force){
 
     Name2Track track_list;
@@ -1062,17 +1058,13 @@ void EMRDb::load_track_list(string db_id, BufferedFile *_pbf, bool force){
             vdebug("Loading %s track list\n", db_id.c_str());
         }
             
-        if (!_pbf && pbf->open(filename.c_str(), "r", true)) {
+        if (!_pbf && pbf->open(filename.c_str(), "r")) {
             if (errno != ENOENT){
                 verror("Failed to open file %s: %s", filename.c_str(), strerror(errno));
             }
 
             create_track_list_file(db_id, NULL);
             continue;
-        }
-
-        if (!_pbf){
-            vdebug("R lock acquired\n");
         }
 
         pbf->seek(0, SEEK_SET); // rewind the file position
@@ -1245,31 +1237,49 @@ void EMRDb::load_track_list(string db_id, BufferedFile *_pbf, bool force){
 void EMRDb::load_track(const char *track_name, const string& db_id){
 
     string filename = track_filename(db_id, track_name);
-    Name2Track::iterator itrack = m_tracks.find(track_name);
-
-    vdebug("Adding track %s to DB\n", track_name);
-
-    if (itrack == m_tracks.end()){
-        m_track_names[db_id].push_back(track_name);
-    } else {
-        delete itrack->second.track;
-        m_tracks.erase(itrack);
-    }
-
-    BufferedFile bf;
-    load_track_list(db_id, bf); // lock track list for write
-
-    EMRTrack *track = EMRTrack::unserialize(track_name, filename.c_str());
-    itrack = m_tracks.find(track_name); // search again, load_track_list might
-                                        // have loaded this track already
     
-    if (itrack == m_tracks.end()){
-        m_tracks.emplace(track_name, TrackInfo(track, filename.c_str(), track->timestamp(), db_id));
-    } else {      
-        itrack->second = TrackInfo(track, filename.c_str(), track->timestamp(), db_id);
-    }
+    vdebug("Adding track %s to DB\n", track_name);
+    
+    int lock_fd = acquire_writer_lock(track_list_filename(db_id));
+
+    try {
+        load_track_list(db_id, NULL); // lock track list for write
+
+        Name2Track::iterator itrack = m_tracks.find(track_name);
+
+        if (itrack == m_tracks.end()){
+            // Check if it's already in track_names (maybe from reload?)
+            auto &names = m_track_names[db_id];
+            if (std::find(names.begin(), names.end(), track_name) == names.end()) {
+                names.push_back(track_name);
+            }
+        } else {
+            delete itrack->second.track;
+            m_tracks.erase(itrack);
+        }
+
+        EMRTrack *track = EMRTrack::unserialize(track_name, filename.c_str());
+        itrack = m_tracks.find(track_name); // search again, load_track_list might
+                                            // have loaded this track already
         
-    update_track_list_file(m_tracks, db_id, bf);
+        if (itrack == m_tracks.end()){
+            m_tracks.emplace(track_name, TrackInfo(track, filename.c_str(), track->timestamp(), db_id));
+        } else {      
+            itrack->second = TrackInfo(track, filename.c_str(), track->timestamp(), db_id);
+        }
+            
+        BufferedFile bf;
+        if (bf.open(track_list_filename(db_id).c_str(), "w", false, true)) {
+             verror("Failed to open file %s: %s", track_list_filename(db_id).c_str(), strerror(errno));
+        }
+        update_track_list_file(m_tracks, db_id, bf);
+        bf.close();
+    }
+    catch (...) {
+        release_writer_lock(lock_fd);
+        throw;
+    }
+    release_writer_lock(lock_fd);
 }
 
 void EMRDb::unload_track(const char *track_name, const bool& overridden, const bool& soft){
@@ -1280,55 +1290,77 @@ void EMRDb::unload_track(const char *track_name, const bool& overridden, const b
         return;
 
     string db_id = itrack->second.db_id;
+    int lock_fd = -1;
 
-    vector<string>::iterator itr = find(m_track_names[db_id].begin(), m_track_names[db_id].end(), track_name);
-
-    if (itr != m_track_names[db_id].end()) {
-        m_track_names[db_id].erase(itr);
-        vdebug("Unloaded track %s from memory", track_name);
-    }
-
-    //If the track was overriding another track
-    //touch  the relevant  .naryn file  so next
-    //refresh will reload the overridden track 
-    
-    if ((itrack->second.dbs.size() > 0) || overridden) {
-
-        int fd;
-
-        for (int i=0; i < (int)m_rootdirs.size(); i++) {
-            if ((fd = open(track_list_filename(m_rootdirs[i]).c_str(), O_WRONLY, 0)) == -1) {
-                verror("Failed opening file %s", track_list_filename(m_rootdirs[i]).c_str());
-            }
-            futimens(fd, NULL);
+    if (!soft) {
+        lock_fd = acquire_writer_lock(track_list_filename(db_id));
+        try {
+            load_track_list(db_id, NULL); 
+        } catch (...) {
+            release_writer_lock(lock_fd);
+            throw;
         }
+
+        itrack = m_tracks.find(track_name);
+        if (itrack == m_tracks.end()) {
+             release_writer_lock(lock_fd);
+             return;
+        }
+    }
+
+    try {
+        vector<string>::iterator itr = find(m_track_names[db_id].begin(), m_track_names[db_id].end(), track_name);
+
+        if (itr != m_track_names[db_id].end()) {
+            m_track_names[db_id].erase(itr);
+            vdebug("Unloaded track %s from memory", track_name);
+        }
+
+        //If the track was overriding another track
+        //touch  the relevant  .naryn file  so next
+        //refresh will reload the overridden track 
         
+        if ((itrack->second.dbs.size() > 0) || overridden) {
+
+            int fd;
+
+            for (int i=0; i < (int)m_rootdirs.size(); i++) {
+                if ((fd = open(track_list_filename(m_rootdirs[i]).c_str(), O_WRONLY, 0)) == -1) {
+                    verror("Failed opening file %s", track_list_filename(m_rootdirs[i]).c_str());
+                }
+                futimens(fd, NULL);
+                close(fd);
+            }
+            
+        }
+
+        delete itrack->second.track;
+        itrack->second.track = NULL;
+
+        m_tracks.erase(track_name);
+
+        if (!soft) {
+            BufferedFile bf;
+            if (bf.open(track_list_filename(db_id).c_str(), "w", false, true)) {
+                 verror("Failed to open file %s: %s", track_list_filename(db_id).c_str(), strerror(errno));
+            }
+            update_track_list_file(m_tracks, db_id, bf);
+            bf.close();
+        }
+    }
+    catch (...) {
+        if (lock_fd != -1) release_writer_lock(lock_fd);
+        throw;
     }
 
-    delete itrack->second.track;
-    itrack->second.track = NULL;
-
-    BufferedFile bf;
-
-    if (!soft) {
-        load_track_list(db_id, bf); // lock track list for write
-    }
-
-    m_tracks.erase(track_name);
-
-    if (!soft) {
-        update_track_list_file(m_tracks, db_id, bf);
-    }
-     
+    if (lock_fd != -1) release_writer_lock(lock_fd);
 }
 
 EMRDb::Track2Attrs EMRDb::get_tracks_attrs(const vector<string> &tracks, vector<string> &attrs) {
     Track2Attrs res;
     
     vector<bool> tracks_attrs_loaded(m_rootdirs.size());
-    vector<BufferedFile> locks(m_rootdirs.size());
 
-    lock_track_lists(locks, "r+");
     string db_id; 
     int db_idx;
 
@@ -1348,7 +1380,7 @@ EMRDb::Track2Attrs EMRDb::get_tracks_attrs(const vector<string> &tracks, vector<
         }
 
         if (!tracks_attrs_loaded[db_idx]) {
-            load_tracks_attrs(db_id, true);
+            load_tracks_attrs(db_id);
             tracks_attrs_loaded[db_idx] = true;
         }
 
@@ -1375,13 +1407,9 @@ EMRDb::Track2Attrs EMRDb::get_tracks_attrs(const vector<string> &tracks, vector<
 
 void EMRDb::set_track_attr(const char *trackname, const char *attr,
                            const char *val, const bool& update) {
-    vector<BufferedFile> locks(m_rootdirs.size());
-    lock_track_lists(locks, "r+");
-
     Name2Track::iterator itrack = m_tracks.find(trackname);
 
     string db_id; 
-    int db_idx;
     string track_attrs_fname;
 
     if (itrack == m_tracks.end()) {
@@ -1390,20 +1418,12 @@ void EMRDb::set_track_attr(const char *trackname, const char *attr,
             verror("Track %s does not exist", trackname);
         } 
         db_id = m_rootdirs[0]; // logical tracks are allowed only on the global db
-        db_idx = 0;
         track_attrs_fname = logical_track_attrs_filename(trackname);
     } else {
         db_id = itrack->second.db_id;
-        db_idx = get_db_idx(db_id);
         track_attrs_fname = track_attrs_filename(db_id, trackname);
     }
     
-    for (int i=0; i < (int)m_rootdirs.size(); i++) {
-        if (i != db_idx) {
-            locks[i].close(); // release lock for the other spaces
-        }
-    }  
-
     TrackAttrs track_attrs = EMRTrack::load_attrs(trackname, track_attrs_fname.c_str());
 
     if (val) {
@@ -1415,7 +1435,7 @@ void EMRDb::set_track_attr(const char *trackname, const char *attr,
 
     EMRTrack::save_attrs(trackname, track_attrs_fname.c_str(), track_attrs);
 
-    load_tracks_attrs(db_id, true);
+    load_tracks_attrs(db_id);
 
     if (track_attrs.empty()){
         m_track2attrs[db_id].erase(trackname);
@@ -1425,23 +1445,13 @@ void EMRDb::set_track_attr(const char *trackname, const char *attr,
     }
 
     if (update){
-        update_tracks_attrs_file(db_id, true);
+        update_tracks_attrs_file(db_id);
     }
     
 }
 
-void EMRDb::load_tracks_attrs(string db_id, bool locked)
+void EMRDb::load_tracks_attrs(string db_id)
 {
-    BufferedFile lock;
-    int db_idx = get_db_idx(db_id);
-    if (!locked){
-        lock_track_list(db_id, lock, "r+");            
-        if (db_idx == 0){
-            BufferedFile lock1;
-            lock_logical_track_list(lock1, "r+");
-        }
-    }
-
     while (1)
     {
         BufferedFile bf;
@@ -1451,7 +1461,7 @@ void EMRDb::load_tracks_attrs(string db_id, bool locked)
             if (errno != ENOENT)
                 verror("Failed to open file %s: %s", filename.c_str(),
                        strerror(errno));
-            create_tracks_attrs_file(db_id, true);
+            create_tracks_attrs_file(db_id);
             continue;
         }
 
@@ -1528,7 +1538,7 @@ void EMRDb::load_tracks_attrs(string db_id, bool locked)
                 vwarning("Invalid format of file %s, rebuilding it",
                          bf.file_name().c_str());
                 bf.close();
-                create_tracks_attrs_file(db_id, true);
+                create_tracks_attrs_file(db_id);
                 continue;
             }
         }
@@ -1541,18 +1551,9 @@ void EMRDb::load_tracks_attrs(string db_id, bool locked)
 }
 
 
-void EMRDb::create_tracks_attrs_file(string db_id, bool locked)
+void EMRDb::create_tracks_attrs_file(string db_id)
 {
-    BufferedFile lock;
     int db_idx = get_db_idx(db_id);
-
-    if (!locked){
-        lock_track_list(db_id, lock, "r+");
-        if (db_idx == 0){
-            BufferedFile lock1;
-            lock_logical_track_list(lock1, "r+");
-        }
-    }
 
     EMRProgressReporter progress;    
     if (db_idx == 0){ // logical tracks are allowed only on the global db
@@ -1595,44 +1596,44 @@ void EMRDb::create_tracks_attrs_file(string db_id, bool locked)
 
     vdebug("Found %lu tracks with attributes\n",
            m_track2attrs[db_id].size());
-    update_tracks_attrs_file(db_id, true);
+    update_tracks_attrs_file(db_id);
 }
 
-void EMRDb::update_tracks_attrs_file(string db_id, bool locked) {
-    BufferedFile lock;
-    if (!locked){
-        lock_track_list(db_id, lock, "r+");
-        int db_idx = get_db_idx(db_id);
-        if (db_idx == 0){
-            BufferedFile lock1;
-            lock_logical_track_list(lock1, "r+");
-        }
-    }
-
+void EMRDb::update_tracks_attrs_file(string db_id) {
     BufferedFile bf;
     string filename = tracks_attrs_filename(db_id);
 
-    vdebug("Creating %s with attributes from %lu tracks", filename.c_str(), m_track2attrs[db_id].size());
+    int lock_fd = acquire_writer_lock(filename);
 
-    if (bf.open(filename.c_str(), "w")){
-        verror("Failed to open file %s: %s", filename.c_str(), strerror(errno));
-    }
+    try {
+        vdebug("Creating %s with attributes from %lu tracks", filename.c_str(), m_track2attrs[db_id].size());
 
-    for (auto const &track2attr : m_track2attrs[db_id]) {
-
-        bf.write(track2attr.first.c_str(), track2attr.first.size() + 1); // track name
-        
-        uint32_t num_attrs = (uint32_t)track2attr.second.size(); // number of attributes
-
-        bf.write(&num_attrs, sizeof(num_attrs));
-
-        for (const auto &attr : track2attr.second) {
-            bf.write(attr.first.c_str(), attr.first.size() + 1);   // attribute
-            bf.write(attr.second.c_str(), attr.second.size() + 1); // value
+        if (bf.open(filename.c_str(), "w", false, true)){
+            verror("Failed to open file %s: %s", filename.c_str(), strerror(errno));
         }
-    }
 
-    if (bf.error()){
-        verror("Error while writing file %s: %s\n", bf.file_name().c_str(), strerror(errno));
+        for (auto const &track2attr : m_track2attrs[db_id]) {
+
+            bf.write(track2attr.first.c_str(), track2attr.first.size() + 1); // track name
+            
+            uint32_t num_attrs = (uint32_t)track2attr.second.size(); // number of attributes
+
+            bf.write(&num_attrs, sizeof(num_attrs));
+
+            for (const auto &attr : track2attr.second) {
+                bf.write(attr.first.c_str(), attr.first.size() + 1);   // attribute
+                bf.write(attr.second.c_str(), attr.second.size() + 1); // value
+            }
+        }
+
+        if (bf.error()){
+            verror("Error while writing file %s: %s\n", bf.file_name().c_str(), strerror(errno));
+        }
+        bf.close();
     }
+    catch (...) {
+        release_writer_lock(lock_fd);
+        throw;
+    }
+    release_writer_lock(lock_fd);
 }

--- a/src/EMRDb.cpp
+++ b/src/EMRDb.cpp
@@ -198,8 +198,15 @@ void EMRDb::load_logical_tracks_from_disk() {
 
             snprintf(filename, sizeof(filename), "%s/%s", logical_tracks_dir().c_str(),
                     dirp->d_name);
-            if (stat(filename, &fs))
+            // A name can vanish between readdir and stat: metadata writes stage a
+            // <file>.tmp.<host>.<pid> in this directory and rename it away, and NFS leaves
+            // .nfsXXXX silly-rename entries that disappear when the last reader closes. Neither
+            // is ours to index, and neither is an error - skip and carry on.
+            if (stat(filename, &fs)) {
+                if (errno == ENOENT)
+                    continue;
                 verror("Failed to stat file %s: %s", filename, strerror(errno));
+            }
 
             // is it a normal file having file extension of a track?
             if (S_ISREG(fs.st_mode) &&
@@ -774,19 +781,10 @@ int EMRDb::acquire_writer_lock(const string &base_filename) {
         return -1; // already held further up this call stack
     }
 
-    // The db can be written by more than one uid (a shared/curated db plus per-user dbs), so the
-    // lock file must be writable by all of them. The mode passed to open() is masked by umask,
-    // which would typically leave it 0644 and owned by whoever happened to create it first -
-    // every other user then fails to open it O_RDWR. Create it exclusively and fchmod past the
-    // umask; if it already exists, just open it.
-    int fd = open(lock_path.c_str(), O_RDWR | O_CREAT | O_EXCL, 0666);
-    if (fd != -1) {
-        if (fchmod(fd, 0666) == -1) {
-            vdebug("Failed to chmod lock file %s: %s", lock_path.c_str(), strerror(errno));
-        }
-    } else if (errno == EEXIST) {
-        fd = open(lock_path.c_str(), O_RDWR);
-    }
+    // 0666 here lands as 0660 in practice: Naryn's ctor sets umask(07), so the lock file gets the
+    // same group-writable mode as every other file naryn writes. That is deliberate - anyone with
+    // write access to the db already has to be in its group, so no extra widening is warranted.
+    int fd = open(lock_path.c_str(), O_RDWR | O_CREAT, 0666);
     if (fd == -1) {
          verror("Failed to open lock file %s: %s", lock_path.c_str(), strerror(errno));
     }
@@ -1013,10 +1011,14 @@ void EMRDb::create_track_list_file(string db_id, BufferedFile *_pbf) {
 
             snprintf(filename, sizeof(filename), "%s/%s", db_id.c_str(), dirp->d_name);
 
+            // See the logical-tracks scan: a staging or NFS silly-rename entry can disappear
+            // between readdir and stat. Not an error, just not something to index.
             if (stat(filename, &fs)){
+                if (errno == ENOENT)
+                    continue;
                 verror("Failed to stat file %s: %s", filename, strerror(errno));
             }
-                
+
             if (S_ISREG(fs.st_mode) && (uint64_t)len > TRACK_FILE_EXT.size() &&
                 !strncmp(dirp->d_name + len - TRACK_FILE_EXT.size(),
                          TRACK_FILE_EXT.c_str(), TRACK_FILE_EXT.size())) {
@@ -1468,10 +1470,14 @@ void EMRDb::set_track_attr(const char *trackname, const char *attr,
         track_attrs_fname = track_attrs_filename(db_id, trackname);
     }
     
-    // Setting one attribute is a read-modify-write of the whole per-track attrs file, so it
-    // needs the writer lock even though save_attrs itself is atomic: without it two concurrent
-    // setters both read the old set and the second one's write drops the first one's attribute.
-    int lock_fd = acquire_writer_lock(track_attrs_fname);
+    // Setting one attribute is a read-modify-write of two files: the per-track attrs file, and
+    // the db's aggregate .attrs cache that every reader is actually served from. Both have to sit
+    // in ONE critical section, and it has to be the aggregate's lock - a per-track lock would let
+    // two setters on *different* tracks run concurrently, each rewrite the whole aggregate from
+    // its own view, and the loser's attribute would vanish from every fresh session while its
+    // per-track file still held the value. Lock the aggregate for the whole function; the nested
+    // acquire inside update_tracks_attrs_file below sees we already hold it and no-ops.
+    int lock_fd = acquire_writer_lock(tracks_attrs_filename(db_id));
 
     try {
         TrackAttrs track_attrs = EMRTrack::load_attrs(trackname, track_attrs_fname.c_str());
@@ -1493,17 +1499,16 @@ void EMRDb::set_track_attr(const char *trackname, const char *attr,
         else {
             m_track2attrs[db_id][trackname] = track_attrs;
         }
+
+        if (update){
+            update_tracks_attrs_file(db_id);
+        }
     }
     catch (...) {
         release_writer_lock(lock_fd);
         throw;
     }
     release_writer_lock(lock_fd);
-
-    if (update){
-        update_tracks_attrs_file(db_id);
-    }
-
 }
 
 void EMRDb::load_tracks_attrs(string db_id)

--- a/src/EMRDb.cpp
+++ b/src/EMRDb.cpp
@@ -336,6 +336,7 @@ void EMRDb::update_logical_tracks_file() {
         bf.close();
     }
     catch (...) {
+        bf.discard();
         release_writer_lock(lock_fd);
         throw;
     }
@@ -940,6 +941,8 @@ void EMRDb::reload() {
 void EMRDb::create_track_list_file(string db_id, BufferedFile *_pbf) {
     DIR *dir = NULL;
     int lock_fd = -1;
+    BufferedFile bf;
+    BufferedFile *pbf = _pbf ? _pbf : &bf;
 
     vdebug("Rescanning %s dir to acquire list of tracks", db_id.c_str());
 
@@ -948,9 +951,6 @@ void EMRDb::create_track_list_file(string db_id, BufferedFile *_pbf) {
     }
 
     try {
-        BufferedFile bf;
-        BufferedFile *pbf = _pbf ? _pbf : &bf;
-
         if (!_pbf) {
             vdebug("Opening %s track list for write", db_id.c_str());
             string filename = track_list_filename(db_id);
@@ -1006,6 +1006,7 @@ void EMRDb::create_track_list_file(string db_id, BufferedFile *_pbf) {
         if (dir){
             closedir(dir);
         }
+        pbf->discard();
         if (lock_fd != -1) release_writer_lock(lock_fd);
         throw;
     }
@@ -1241,6 +1242,7 @@ void EMRDb::load_track(const char *track_name, const string& db_id){
     vdebug("Adding track %s to DB\n", track_name);
     
     int lock_fd = acquire_writer_lock(track_list_filename(db_id));
+    BufferedFile bf;
 
     try {
         load_track_list(db_id, NULL); // lock track list for write
@@ -1268,7 +1270,6 @@ void EMRDb::load_track(const char *track_name, const string& db_id){
             itrack->second = TrackInfo(track, filename.c_str(), track->timestamp(), db_id);
         }
             
-        BufferedFile bf;
         if (bf.open(track_list_filename(db_id).c_str(), "w", false, true)) {
              verror("Failed to open file %s: %s", track_list_filename(db_id).c_str(), strerror(errno));
         }
@@ -1276,6 +1277,7 @@ void EMRDb::load_track(const char *track_name, const string& db_id){
         bf.close();
     }
     catch (...) {
+        bf.discard();
         release_writer_lock(lock_fd);
         throw;
     }
@@ -1291,6 +1293,7 @@ void EMRDb::unload_track(const char *track_name, const bool& overridden, const b
 
     string db_id = itrack->second.db_id;
     int lock_fd = -1;
+    BufferedFile bf;
 
     if (!soft) {
         lock_fd = acquire_writer_lock(track_list_filename(db_id));
@@ -1340,7 +1343,6 @@ void EMRDb::unload_track(const char *track_name, const bool& overridden, const b
         m_tracks.erase(track_name);
 
         if (!soft) {
-            BufferedFile bf;
             if (bf.open(track_list_filename(db_id).c_str(), "w", false, true)) {
                  verror("Failed to open file %s: %s", track_list_filename(db_id).c_str(), strerror(errno));
             }
@@ -1349,6 +1351,7 @@ void EMRDb::unload_track(const char *track_name, const bool& overridden, const b
         }
     }
     catch (...) {
+        bf.discard();
         if (lock_fd != -1) release_writer_lock(lock_fd);
         throw;
     }

--- a/src/EMRDb.h
+++ b/src/EMRDb.h
@@ -139,7 +139,7 @@ public:
                         const char *val, const bool &update);
 
     // Writes data into tracks attributes file.
-    void update_tracks_attrs_file(string db_id, bool locked);
+    void update_tracks_attrs_file(string db_id);
 
     unsigned id(uint64_t idx);
     uint64_t id2idx(unsigned id);  // returns id index given id
@@ -205,6 +205,10 @@ protected:
     string logical_tracks_filename() const { return m_rootdirs[0] + "/" + LOGICAL_TRACKS_FILENAME;}
     string ids_filename() const { return m_rootdirs[0] + "/" + IDS_FILENAME; }
 
+    // Helper to acquire a persistent lock file for writing
+    int acquire_writer_lock(const string &base_filename);
+    void release_writer_lock(int fd);
+
     // make sure that rootdirs are readable
     void validate_rootdirs(const vector<string> &rootdirs);
 
@@ -214,15 +218,6 @@ protected:
     void clear_ids();
 
     void cache_tracks();
-
-    // opens and locks track list file according to the mode: "r", "r+", "w"
-    void lock_track_list(string db_id, BufferedFile &lock, const char *mode);
-
-    // opens and locks track list files (both global and user) according to the mode: "r", "r+", "w"
-    void lock_track_lists(vector<BufferedFile> &locks, const char *mode);
-
-    // opens and locks logical track list file according to the mode: "r", "r+", "w"
-    void lock_logical_track_list(BufferedFile &lock, const char *mode);
 
     // Scans root directory for tracks, creates track list file with the gathered data.
     void create_track_list_file(string db_id, BufferedFile *pbf);
@@ -237,17 +232,14 @@ protected:
     // Removes outdated tracks from memory.
     void load_track_list(string db_id, BufferedFile *pbf, bool force=false);
 
-    // Loads track list before update (opens the file for r+w and locks it).
-    void load_track_list(string db_id, BufferedFile &bf, bool force=false);
-
     // Loads logical track list
     void load_logical_tracks();
 
     // Scans root directory for tracks attributes, creates tracks attributes file with the gathered data.
-    void create_tracks_attrs_file(string db_id, bool locked);
+    void create_tracks_attrs_file(string db_id);
 
     // Loads track attributes file. If corrupted or missing, recreates it.
-    void load_tracks_attrs(string db_id, bool locked);
+    void load_tracks_attrs(string db_id);
 
     void create_ids_file();
     void load_ids();

--- a/src/EMRDb.h
+++ b/src/EMRDb.h
@@ -2,6 +2,7 @@
 #define EMRDB_H_INCLUDED
 
 #include <map>
+#include <set>
 #include <sys/mman.h>
 #include <unordered_map>
 #include <unordered_set>
@@ -205,9 +206,16 @@ protected:
     string logical_tracks_filename() const { return m_rootdirs[0] + "/" + LOGICAL_TRACKS_FILENAME;}
     string ids_filename() const { return m_rootdirs[0] + "/" + IDS_FILENAME; }
 
-    // Helper to acquire a persistent lock file for writing
+    // Helper to acquire a persistent lock file for writing. Reentrant: a nested acquire of a
+    // path this process already holds returns -1 and releases nothing, because closing any fd
+    // on a file drops all of the process's fcntl locks on it.
     int acquire_writer_lock(const string &base_filename);
     void release_writer_lock(int fd);
+
+    // Writer locks currently held by this process, by lock-file path and by fd. Not guarded by
+    // a mutex: naryn runs single-threaded under R.
+    std::set<string> m_held_lock_paths;
+    std::map<int, string> m_held_lock_fds;
 
     // make sure that rootdirs are readable
     void validate_rootdirs(const vector<string> &rootdirs);

--- a/src/EMRTrack.cpp
+++ b/src/EMRTrack.cpp
@@ -236,7 +236,9 @@ void EMRTrack::save_attrs(const char *track, const char *filename, const TrackAt
 
 	BufferedFile bfile;
 
-	if (bfile.open(filename, "wb"))
+	// Staged and renamed into place, like every other metadata write: readers of this file take
+	// no lock, so an in-place truncate-and-rewrite would expose a partial (or empty) attrs file.
+	if (bfile.open(filename, "wb", false, true))
 		TGLError<EMRTrack>(FILE_ERROR, "Failed to write attributes file %s: %s", filename, strerror(errno));
 
 	for (TrackAttrs::const_iterator iattr = attrs.begin(); iattr != attrs.end(); ++iattr) {
@@ -246,6 +248,12 @@ void EMRTrack::save_attrs(const char *track, const char *filename, const TrackAt
 		}
 	}
 
-	if (bfile.error())
+	if (bfile.error()) {
+		bfile.discard();
+		TGLError<EMRTrack>(FILE_ERROR, "Failed to write attributes file %s: %s", filename, strerror(errno));
+	}
+
+	// close() performs the rename; a failure there means the update was thrown away.
+	if (bfile.close())
 		TGLError<EMRTrack>(FILE_ERROR, "Failed to write attributes file %s: %s", filename, strerror(errno));
 }

--- a/src/NRTrack.cpp
+++ b/src/NRTrack.cpp
@@ -436,8 +436,8 @@ SEXP emr_set_track_attr(SEXP _track, SEXP _attr, SEXP _value, SEXP _update, SEXP
 SEXP update_tracks_attrs_file(SEXP _db, SEXP _envir) {
     try {
         Naryn naryn(_envir, false);
-        string db_id(CHAR(Rf_asChar(_db)));
-        g_db->update_tracks_attrs_file(db_id, false);
+        string db_id = CHAR(Rf_asChar(_db));
+        g_db->update_tracks_attrs_file(db_id);
     } catch (TGLException &e) {
         rerror("%s", e.msg());
     } catch (const bad_alloc &e) {
@@ -518,4 +518,3 @@ SEXP emr_track_db(SEXP _track, SEXP _envir) {
     return R_NilValue;
 }
 }
-

--- a/src/naryn-init.cpp
+++ b/src/naryn-init.cpp
@@ -58,6 +58,7 @@ extern SEXP emr_track_unique(SEXP, SEXP);
 extern SEXP emr_track_percentile(SEXP, SEXP, SEXP, SEXP);
 extern SEXP emr_get_tracks_attrs(SEXP, SEXP, SEXP);
 extern SEXP emr_set_track_attr(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP update_tracks_attrs_file(SEXP, SEXP);
 extern SEXP emr_track_dbs(SEXP, SEXP);
 extern SEXP emr_track_db(SEXP, SEXP);
 extern SEXP emr_track_create(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP,
@@ -121,6 +122,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"emr_track_percentile", (DL_FUNC) &emr_track_percentile, 4},
     {"emr_get_tracks_attrs", (DL_FUNC) &emr_get_tracks_attrs, 3},
     {"emr_set_track_attr", (DL_FUNC) &emr_set_track_attr, 5},
+    {"update_tracks_attrs_file", (DL_FUNC) &update_tracks_attrs_file, 2},
     {"emr_track_dbs", (DL_FUNC) &emr_track_dbs, 2},
     {"emr_track_db", (DL_FUNC) &emr_track_db, 2},
     {"emr_track_create", (DL_FUNC) &emr_track_create, 11},


### PR DESCRIPTION
The current locking architecture uses fcntl read-locks ("r") or exclusive read-locks ("r+") on metadata files (.naryn, .attrs). On NFS, this causes severe performance degradation and serialization of worker processes during high-concurrency read operations.

This commit refactors the persistence layer to use an Atomic Rename / Snapshot pattern, eliminating the need for read locks entirely.