### PR TITLE
Allow atomic in-place track overwrite via override

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: naryn
 Title: Native Access Medical Record Retriever for High Yield Analytics
-Version: 2.7.1
+Version: 2.7.2
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `emr_track.create` and `emr_track.import` can now rewrite a track in its own db when `override = TRUE`. Previously `override` only covered shadowing a track from another db, and rewriting in place required `emr_track.rm()` first - which left the track missing for the whole rebuild, so anything reading it in that window failed.
 * Track writes are now staged to a temporary file and renamed into place. `rename(2)` replaces the target atomically, so a concurrent reader always sees either the complete previous track or the complete new one. `emr_track.import` already staged, but unlinked the target before the move, which reopened the same window.
+* Note that rewriting a track in place is not the same as `emr_track.rm()` followed by a fresh write: the track's attributes, variables and file permissions are kept, so anything the previous write set and the new one does not will survive the rewrite. Remove the track first if you need a clean slate.
+* A read-only track can no longer be overridden in its own db, matching `emr_track.rm`, `emr_track.mv` and `emr_track.addto`.
 
 # naryn 2.7.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# naryn 2.7.2
+
+* `emr_track.create` and `emr_track.import` can now rewrite a track in its own db when `override = TRUE`. Previously `override` only covered shadowing a track from another db, and rewriting in place required `emr_track.rm()` first - which left the track missing for the whole rebuild, so anything reading it in that window failed.
+* Track writes are now staged to a temporary file and renamed into place. `rename(2)` replaces the target atomically, so a concurrent reader always sees either the complete previous track or the complete new one. `emr_track.import` already staged, but unlinked the target before the move, which reopened the same window.
+
 # naryn 2.7.1
 
 * Merged the CRAN-portability fixes from 2.6.32-2.6.34 onto the new locking mechanism introduced in 2.7.0.

--- a/R/track.R
+++ b/R/track.R
@@ -198,7 +198,10 @@ emr_track.addto <- function(track, src, force = FALSE, remove_unknown = FALSE) {
 #' @param override Boolean indicating whether the write intends to replace an existing track (default FALSE).
 #' Covers both shadowing a track that lives in another db and rewriting one in this db. The new track is
 #' written to a staging file and renamed into place, so readers never observe the track missing or partial
-#' - there is no need to \code{emr_track.rm()} it first.
+#' - there is no need to \code{emr_track.rm()} it first. Rewriting in place keeps the existing track's
+#' attributes, variables and file permissions, unlike \code{emr_track.rm()} followed by a fresh write,
+#' which discards them: anything the previous write set and the new one does not will still be there
+#' afterwards. A read-only track is never overridden in its own db.
 #'
 #' @return None.
 #'
@@ -353,7 +356,10 @@ emr_track.ids <- function(track) {
 #' @param override Boolean indicating whether the write intends to replace an existing track (default FALSE).
 #' Covers both shadowing a track that lives in another db and rewriting one in this db. The new track is
 #' written to a staging file and renamed into place, so readers never observe the track missing or partial
-#' - there is no need to \code{emr_track.rm()} it first.
+#' - there is no need to \code{emr_track.rm()} it first. Rewriting in place keeps the existing track's
+#' attributes, variables and file permissions, unlike \code{emr_track.rm()} followed by a fresh write,
+#' which discards them: anything the previous write set and the new one does not will still be there
+#' afterwards. A read-only track is never overridden in its own db.
 #' @param remove_unknown if 'TRUE', removes unknown ids (ids that are not present at 'patients.dob' track) from the data. Otherwise, an error is thrown.
 #'
 #' @return None.

--- a/R/track.R
+++ b/R/track.R
@@ -195,7 +195,10 @@ emr_track.addto <- function(track, src, force = FALSE, remove_unknown = FALSE) {
 #' implicitly based on track expressions. See also 'iterator' section.
 #' @param keepref If 'TRUE' references are preserved in the iterator
 #' @param filter Iterator filter
-#' @param override Boolean indicating whether the creation intends to override an existing track (default FALSE)
+#' @param override Boolean indicating whether the write intends to replace an existing track (default FALSE).
+#' Covers both shadowing a track that lives in another db and rewriting one in this db. The new track is
+#' written to a staging file and renamed into place, so readers never observe the track missing or partial
+#' - there is no need to \code{emr_track.rm()} it first.
 #'
 #' @return None.
 #'
@@ -347,7 +350,10 @@ emr_track.ids <- function(track) {
 #' @param space db dir string (path), one of the paths supplied in emr_db.connect
 #' @param categorical if 'TRUE' track is marked as categorical
 #' @param src file name or data-frame containing the track records
-#' @param override Boolean indicating whether the creation intends to override an existing track (default FALSE)
+#' @param override Boolean indicating whether the write intends to replace an existing track (default FALSE).
+#' Covers both shadowing a track that lives in another db and rewriting one in this db. The new track is
+#' written to a staging file and renamed into place, so readers never observe the track missing or partial
+#' - there is no need to \code{emr_track.rm()} it first.
 #' @param remove_unknown if 'TRUE', removes unknown ids (ids that are not present at 'patients.dob' track) from the data. Otherwise, an error is thrown.
 #'
 #' @return None.

--- a/man/emr_track.create.Rd
+++ b/man/emr_track.create.Rd
@@ -37,7 +37,10 @@ implicitly based on track expressions. See also 'iterator' section.}
 
 \item{filter}{Iterator filter}
 
-\item{override}{Boolean indicating whether the creation intends to override an existing track (default FALSE)}
+\item{override}{Boolean indicating whether the write intends to replace an existing track (default FALSE).
+Covers both shadowing a track that lives in another db and rewriting one in this db. The new track is
+written to a staging file and renamed into place, so readers never observe the track missing or partial
+- there is no need to \code{emr_track.rm()} it first.}
 }
 \value{
 None.

--- a/man/emr_track.create.Rd
+++ b/man/emr_track.create.Rd
@@ -40,7 +40,10 @@ implicitly based on track expressions. See also 'iterator' section.}
 \item{override}{Boolean indicating whether the write intends to replace an existing track (default FALSE).
 Covers both shadowing a track that lives in another db and rewriting one in this db. The new track is
 written to a staging file and renamed into place, so readers never observe the track missing or partial
-- there is no need to \code{emr_track.rm()} it first.}
+- there is no need to \code{emr_track.rm()} it first. Rewriting in place keeps the existing track's
+attributes, variables and file permissions, unlike \code{emr_track.rm()} followed by a fresh write,
+which discards them: anything the previous write set and the new one does not will still be there
+afterwards. A read-only track is never overridden in its own db.}
 }
 \value{
 None.

--- a/man/emr_track.import.Rd
+++ b/man/emr_track.import.Rd
@@ -22,7 +22,10 @@ emr_track.import(
 
 \item{src}{file name or data-frame containing the track records}
 
-\item{override}{Boolean indicating whether the creation intends to override an existing track (default FALSE)}
+\item{override}{Boolean indicating whether the write intends to replace an existing track (default FALSE).
+Covers both shadowing a track that lives in another db and rewriting one in this db. The new track is
+written to a staging file and renamed into place, so readers never observe the track missing or partial
+- there is no need to \code{emr_track.rm()} it first.}
 
 \item{remove_unknown}{if 'TRUE', removes unknown ids (ids that are not present at 'patients.dob' track) from the data. Otherwise, an error is thrown.}
 }

--- a/man/emr_track.import.Rd
+++ b/man/emr_track.import.Rd
@@ -25,7 +25,10 @@ emr_track.import(
 \item{override}{Boolean indicating whether the write intends to replace an existing track (default FALSE).
 Covers both shadowing a track that lives in another db and rewriting one in this db. The new track is
 written to a staging file and renamed into place, so readers never observe the track missing or partial
-- there is no need to \code{emr_track.rm()} it first.}
+- there is no need to \code{emr_track.rm()} it first. Rewriting in place keeps the existing track's
+attributes, variables and file permissions, unlike \code{emr_track.rm()} followed by a fresh write,
+which discards them: anything the previous write set and the new one does not will still be there
+afterwards. A read-only track is never overridden in its own db.}
 
 \item{remove_unknown}{if 'TRUE', removes unknown ids (ids that are not present at 'patients.dob' track) from the data. Otherwise, an error is thrown.}
 }

--- a/src/FileUtils.cpp
+++ b/src/FileUtils.cpp
@@ -1,8 +1,11 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+#include <string>
 #if defined(__APPLE__)
     #include <copyfile.h>
 #else
@@ -56,5 +59,42 @@ void FileUtils::move_file(const char *src, const char *tgt) {
             }
         } else
             TGLError(errno, "Error moving file %s to %s: %s\n", src, tgt);
+    }
+}
+
+void FileUtils::atomic_write(const char *tgt, const std::function<void(const char *)> &writer) {
+    // The staging file sits next to the target, so the rename below stays inside one filesystem.
+    std::string stage = std::string(tgt) + ".tmp.XXXXXX";
+    int fd = mkstemp(&stage[0]);
+
+    if (fd == -1)
+        TGLError(errno, "Error creating a staging file for %s: %s", tgt, strerror(errno));
+    close(fd);
+
+    // mkstemp creates the file 0600 and writer() only truncates it, so the mode has to be set
+    // here: the target's own mode if it has one, and whatever the umask calls for otherwise.
+    struct stat tgtstat;
+    mode_t mode;
+
+    if (stat(tgt, &tgtstat) != -1)
+        mode = tgtstat.st_mode & 07777;
+    else {
+        mode_t mask = umask(0);
+        umask(mask);
+        mode = 0666 & ~mask;
+    }
+
+    if (chmod(stage.c_str(), mode) == -1) {
+        auto olderrno = errno;
+        unlink(stage.c_str());
+        TGLError(olderrno, "Error setting permissions of %s: %s", stage.c_str(), strerror(olderrno));
+    }
+
+    try {
+        writer(stage.c_str());
+        FileUtils::move_file(stage.c_str(), tgt);
+    } catch (...) {
+        unlink(stage.c_str());
+        throw;
     }
 }

--- a/src/FileUtils.h
+++ b/src/FileUtils.h
@@ -1,6 +1,8 @@
 #ifndef FILEUTILS_H_INCLUDED
 #define FILEUTILS_H_INCLUDED
 
+#include <functional>
+
 namespace FileUtils {
     // Makes a fast copy of a file while preserving permissions.
     // Throws TGLException on error, TGLException::code contains errno.
@@ -9,6 +11,16 @@ namespace FileUtils {
     // Renames a file or copies it, if the target is located in a different file system.
     // Throws TGLException on error, TGLException::code contains errno.
     void move_file(const char *src, const char *tgt);
+
+    // Replaces tgt in a single step: calls writer() with a staging path in tgt's own directory,
+    // then renames that file into place. A concurrent reader therefore sees either the complete
+    // previous file or the complete new one, never a partial or absent one.
+    // The staging name comes from mkstemp, so no other writer can pick it, including one on
+    // another host sharing the directory over NFS. The staging file is removed if writer() or
+    // the rename throws, and it inherits tgt's permissions when tgt already exists - rename
+    // replaces the target inode, so without this an overwrite would silently reset its mode.
+    // Throws TGLException on error, TGLException::code contains errno.
+    void atomic_write(const char *tgt, const std::function<void(const char *)> &writer);
 }
 
 #endif

--- a/src/NRImport.cpp
+++ b/src/NRImport.cpp
@@ -1,6 +1,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include <string>
+
 #include "EMRDb.h"
 #include "EMRTrack.h"
 #include "FileUtils.h"
@@ -57,9 +59,12 @@ SEXP emr_import(SEXP _track, SEXP _db_id, SEXP _categorical, SEXP _src, SEXP _ad
                 verror("%s directory is not set", db_id.c_str());
             }
 
-            //Error only if exists in the same db, otherwise try overriding
-            if (g_db->track(trackname) && (g_db->track_info(trackname)->db_id == db_id)) {
-                verror("Track %s already exists", trackname.c_str());
+            // Rewriting a track in its own db needs override, same as shadowing one from
+            // another db. The write below is staged and renamed into place, so an in-place
+            // rewrite never leaves readers with a missing or half-written track - callers no
+            // longer have to emr_track.rm() first and expose that window themselves.
+            if (g_db->track(trackname) && (g_db->track_info(trackname)->db_id == db_id) && !toverride) {
+                verror("Track %s already exists, see override argument", trackname.c_str());
             }
             //User must explicitly pass an overriding argument
             if (g_db->track(trackname) && (g_db->track_info(trackname)->db_id != db_id) && !toverride) {
@@ -90,7 +95,9 @@ SEXP emr_import(SEXP _track, SEXP _db_id, SEXP _categorical, SEXP _src, SEXP _ad
 
             track_filename = db_id + string("/") + trackname + EMRDb::TRACK_FILE_EXT;
 
-            if (access(track_filename.c_str(), F_OK) != -1)
+            // A stray file with no track registered for it: still refuse to clobber it silently,
+            // but override is an explicit "rewrite this track", so let it through.
+            if (!toverride && access(track_filename.c_str(), F_OK) != -1)
                 verror("File %s already exists", track_filename.c_str());
         }
 
@@ -174,15 +181,22 @@ SEXP emr_import(SEXP _track, SEXP _db_id, SEXP _categorical, SEXP _src, SEXP _ad
         }
 
 
-        if (access(track_filename.c_str(), F_OK) != -1) {
-            string tmp_filename = track_filename + ".tmp";
+        // Stage next to the target (same directory, so same filesystem) and rename into place.
+        // rename(2) replaces an existing file atomically, so a concurrent reader sees either the
+        // complete previous track or the complete new one - never a partial or absent file. The
+        // unlink that used to precede the move reopened exactly that window, and is not needed:
+        // rename replaces the target by itself. The pid in the suffix keeps two writers of the
+        // same track from clobbering each other's staging file.
+        string tmp_filename = track_filename + ".tmp." + std::to_string(getpid());
+        try {
             EMRTrack::serialize(tmp_filename.c_str(), categorical ? EMRTrack::IS_CATEGORICAL : 0, data);
-            unlink(track_filename.c_str());
             FileUtils::move_file(tmp_filename.c_str(), track_filename.c_str());
-        } else {
-            EMRTrack::serialize(track_filename.c_str(), categorical, data);
+        } catch (...) {
+            unlink(tmp_filename.c_str());
+            throw;
         }
-        
+
+
         if (has_overlap){
             g_db->unload_track(trackname.c_str(), true, true);
         }

--- a/src/NRImport.cpp
+++ b/src/NRImport.cpp
@@ -1,8 +1,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <string>
-
 #include "EMRDb.h"
 #include "EMRTrack.h"
 #include "FileUtils.h"
@@ -181,21 +179,20 @@ SEXP emr_import(SEXP _track, SEXP _db_id, SEXP _categorical, SEXP _src, SEXP _ad
         }
 
 
-        // Stage next to the target (same directory, so same filesystem) and rename into place.
-        // rename(2) replaces an existing file atomically, so a concurrent reader sees either the
-        // complete previous track or the complete new one - never a partial or absent file. The
-        // unlink that used to precede the move reopened exactly that window, and is not needed:
-        // rename replaces the target by itself. The pid in the suffix keeps two writers of the
-        // same track from clobbering each other's staging file.
-        string tmp_filename = track_filename + ".tmp." + std::to_string(getpid());
-        try {
-            EMRTrack::serialize(tmp_filename.c_str(), categorical ? EMRTrack::IS_CATEGORICAL : 0, data);
-            FileUtils::move_file(tmp_filename.c_str(), track_filename.c_str());
-        } catch (...) {
-            unlink(tmp_filename.c_str());
-            throw;
-        }
+        // Rewriting in place really writes this file, unlike shadowing a track from another db,
+        // so honour "read-only" the way emr_track.rm/mv/addto do. Nothing below would stop it:
+        // read-only is a mode on the track file, and rename(2) does not consult the target's
+        // mode, only the directory's.
+        if (access(track_filename.c_str(), F_OK) == 0 && access(track_filename.c_str(), W_OK) != 0)
+            verror("Cannot override track %s: it is read-only.", trackname.c_str());
 
+        // Staged and renamed into place, so a concurrent reader sees either the complete previous
+        // track or the complete new one - never a partial or absent file. The unlink that used to
+        // precede the move reopened exactly that window, and is not needed: rename replaces the
+        // target by itself.
+        FileUtils::atomic_write(track_filename.c_str(), [&](const char *path) {
+            EMRTrack::serialize(path, categorical ? EMRTrack::IS_CATEGORICAL : 0, data);
+        });
 
         if (has_overlap){
             g_db->unload_track(trackname.c_str(), true, true);

--- a/src/NRTrackCreate.cpp
+++ b/src/NRTrackCreate.cpp
@@ -13,8 +13,6 @@
 
 #include <unistd.h>
 
-#include <string>
-
 #include "EMRDb.h"
 #include "EMRTrack.h"
 #include "FileUtils.h"
@@ -94,19 +92,18 @@ SEXP emr_track_create(SEXP _track, SEXP _db_id, SEXP _categorical, SEXP _expr, S
 			g_naryn->verify_max_data_size(data.data.size(), "Result");
 		}
 
-        // Stage next to the target (same directory, so same filesystem) and rename into place.
-        // rename(2) replaces an existing file atomically, so a concurrent reader sees either the
-        // complete previous track or the complete new one - never a partial or absent file. The
-        // pid in the suffix keeps two writers of the same track from clobbering each other's
-        // staging file; the rename itself then just decides who wins.
-        string tmp_filename = track_filename + ".tmp." + std::to_string(getpid());
-        try {
-            EMRTrack::serialize(tmp_filename.c_str(), categorical ? EMRTrack::IS_CATEGORICAL : 0, data);
-            FileUtils::move_file(tmp_filename.c_str(), track_filename.c_str());
-        } catch (...) {
-            unlink(tmp_filename.c_str());
-            throw;
-        }
+        // Rewriting in place really writes this file, unlike shadowing a track from another db,
+        // so honour "read-only" the way emr_track.rm/mv/addto do. Nothing below would stop it:
+        // read-only is a mode on the track file, and rename(2) does not consult the target's
+        // mode, only the directory's.
+        if (access(track_filename.c_str(), F_OK) == 0 && access(track_filename.c_str(), W_OK) != 0)
+            verror("Cannot override track %s: it is read-only.", trackname.c_str());
+
+        // Staged and renamed into place, so a concurrent reader sees either the complete previous
+        // track or the complete new one - never a partial or absent file.
+        FileUtils::atomic_write(track_filename.c_str(), [&](const char *path) {
+            EMRTrack::serialize(path, categorical ? EMRTrack::IS_CATEGORICAL : 0, data);
+        });
 
         if (has_overlap) {
             g_db->unload_track(trackname.c_str(), true, true);

--- a/src/NRTrackCreate.cpp
+++ b/src/NRTrackCreate.cpp
@@ -11,8 +11,13 @@
 #undef error
 #endif
 
+#include <unistd.h>
+
+#include <string>
+
 #include "EMRDb.h"
 #include "EMRTrack.h"
+#include "FileUtils.h"
 #include "naryn.h"
 #include "NRTrackExpressionScanner.h"
 
@@ -46,10 +51,14 @@ SEXP emr_track_create(SEXP _track, SEXP _db_id, SEXP _categorical, SEXP _expr, S
 
         string trackname = { CHAR(Rf_asChar(_track)) };
 
-        if (g_db->track(trackname) && (g_db->track_info(trackname)->db_id == db_id)){
-            verror("Track %s already exists", trackname.c_str());
+        // Rewriting a track in its own db needs override, same as shadowing one from another
+        // db. The write below is staged and renamed into place, so an in-place rewrite never
+        // leaves readers with a missing or half-written track - callers no longer have to
+        // emr_track.rm() first and expose that window themselves.
+        if (g_db->track(trackname) && (g_db->track_info(trackname)->db_id == db_id) && !toverride){
+            verror("Track %s already exists, see override argument", trackname.c_str());
         }
-            
+
         // User must explicitly pass an overriding argument
         if (g_db->track(trackname) && (g_db->track_info(trackname)->db_id != db_id) && !toverride){
             verror("Track %s already exists in db %s, see override argument", trackname.c_str(), g_db->track_info(trackname)->db_id.c_str());
@@ -85,7 +94,19 @@ SEXP emr_track_create(SEXP _track, SEXP _db_id, SEXP _categorical, SEXP _expr, S
 			g_naryn->verify_max_data_size(data.data.size(), "Result");
 		}
 
-        EMRTrack::serialize(track_filename.c_str(), categorical, data);
+        // Stage next to the target (same directory, so same filesystem) and rename into place.
+        // rename(2) replaces an existing file atomically, so a concurrent reader sees either the
+        // complete previous track or the complete new one - never a partial or absent file. The
+        // pid in the suffix keeps two writers of the same track from clobbering each other's
+        // staging file; the rename itself then just decides who wins.
+        string tmp_filename = track_filename + ".tmp." + std::to_string(getpid());
+        try {
+            EMRTrack::serialize(tmp_filename.c_str(), categorical ? EMRTrack::IS_CATEGORICAL : 0, data);
+            FileUtils::move_file(tmp_filename.c_str(), track_filename.c_str());
+        } catch (...) {
+            unlink(tmp_filename.c_str());
+            throw;
+        }
 
         if (has_overlap) {
             g_db->unload_track(trackname.c_str(), true, true);

--- a/tests/testthat/test-track.overwrite.R
+++ b/tests/testthat/test-track.overwrite.R
@@ -1,0 +1,48 @@
+load_test_db()
+
+# Rewriting a track in its own db used to be impossible: both emr_track.import and
+# emr_track.create errored with "Track already exists" regardless of `override`, which only
+# covered shadowing a track from another db. Callers had to emr_track.rm() first, leaving the
+# track absent for the whole rebuild - anything reading it in that window failed.
+
+test_that("emr_track.import can rewrite a track in the same db with override", {
+    a <- emr_extract("track1", keepref = TRUE, names = "value")
+    emr_track.import("ovr_track", "global", categorical = FALSE, src = a)
+    withr::defer(emr_track.rm("ovr_track", force = TRUE))
+
+    expect_error(emr_track.import("ovr_track", "global", categorical = FALSE, src = a))
+
+    b <- emr_extract("track2", keepref = TRUE, names = "value")
+    emr_track.import("ovr_track", "global", categorical = FALSE, src = b, override = TRUE)
+
+    expect_true(emr_track.exists("ovr_track"))
+    got <- emr_extract("ovr_track", keepref = TRUE, names = "value")
+    expect_equal(got$value, b$value)
+})
+
+test_that("emr_track.create can rewrite a track in the same db with override", {
+    emr_track.create("ovr_ctrack", "global", categorical = FALSE, expr = "track1")
+    withr::defer(emr_track.rm("ovr_ctrack", force = TRUE))
+    before <- emr_extract("ovr_ctrack", names = "value")$value
+
+    expect_error(emr_track.create("ovr_ctrack", "global", categorical = FALSE, expr = "track1 + 1"))
+
+    # Same expression shifted by one, so the comparison stays inside a single iterator shape
+    # and only tests that the rewrite actually replaced the stored data.
+    emr_track.create("ovr_ctrack", "global", categorical = FALSE, expr = "track1 + 1", override = TRUE)
+
+    expect_true(emr_track.exists("ovr_ctrack"))
+    expect_equal(emr_extract("ovr_ctrack", names = "value")$value, before + 1)
+})
+
+test_that("overwriting leaves no staging files behind", {
+    a <- emr_extract("track1", keepref = TRUE, names = "value")
+    emr_track.import("ovr_tmp_track", "global", categorical = FALSE, src = a)
+    withr::defer(emr_track.rm("ovr_tmp_track", force = TRUE))
+    emr_track.import("ovr_tmp_track", "global", categorical = FALSE, src = a, override = TRUE)
+    emr_track.create("ovr_tmp_ctrack", "global", categorical = FALSE, expr = "track1", override = TRUE)
+    withr::defer(emr_track.rm("ovr_tmp_ctrack", force = TRUE))
+
+    db_dir <- emr_db.ls()[1]
+    expect_length(list.files(db_dir, pattern = "\\.tmp\\."), 0)
+})

--- a/tests/testthat/test-track.overwrite.R
+++ b/tests/testthat/test-track.overwrite.R
@@ -35,6 +35,45 @@ test_that("emr_track.create can rewrite a track in the same db with override", {
     expect_equal(emr_extract("ovr_ctrack", names = "value")$value, before + 1)
 })
 
+test_that("a read-only track is not overridden in its own db", {
+    a <- emr_extract("track1", keepref = TRUE, names = "value")
+    emr_track.import("ovr_ro_track", "global", categorical = FALSE, src = a)
+    withr::defer({
+        emr_track.readonly("ovr_ro_track", FALSE)
+        emr_track.rm("ovr_ro_track", force = TRUE)
+    })
+    emr_track.readonly("ovr_ro_track", TRUE)
+
+    # rename(2) consults the directory's permissions, not the target file's, so the read-only
+    # mode on the track file does not stop the write by itself - hence the explicit check.
+    b <- emr_extract("track2", keepref = TRUE, names = "value")
+    expect_error(emr_track.import("ovr_ro_track", "global", categorical = FALSE, src = b, override = TRUE), "read-only")
+    expect_error(emr_track.create("ovr_ro_track", "global", categorical = FALSE, expr = "track2", override = TRUE), "read-only")
+
+    expect_true(emr_track.readonly("ovr_ro_track"))
+    expect_equal(emr_extract("ovr_ro_track", keepref = TRUE, names = "value")$value, a$value)
+})
+
+test_that("overriding a track keeps its permissions, attributes and vars", {
+    a <- emr_extract("track1", keepref = TRUE, names = "value")
+    emr_track.import("ovr_keep_track", "global", categorical = FALSE, src = a)
+    withr::defer(emr_track.rm("ovr_keep_track", force = TRUE))
+
+    fname <- file.path(emr_db.ls()[1], "ovr_keep_track.nrtrack")
+    Sys.chmod(fname, "640", use_umask = FALSE)
+    emr_track.attr.set("ovr_keep_track", "description", "before")
+    emr_track.var.set("ovr_keep_track", "v", "before")
+
+    b <- emr_extract("track2", keepref = TRUE, names = "value")
+    emr_track.import("ovr_keep_track", "global", categorical = FALSE, src = b, override = TRUE)
+
+    # The rename replaces the target inode, so the mode has to be carried over explicitly.
+    expect_equal(as.character(file.info(fname)$mode), "640")
+    # Unlike emr_track.rm() + write, an in-place override does not discard these.
+    expect_equal(emr_track.attr.get("ovr_keep_track", "description"), "before")
+    expect_equal(emr_track.var.get("ovr_keep_track", "v"), "before")
+})
+
 test_that("overwriting leaves no staging files behind", {
     a <- emr_extract("track1", keepref = TRUE, names = "value")
     emr_track.import("ovr_tmp_track", "global", categorical = FALSE, src = a)


### PR DESCRIPTION
## Why

`emr_track.create` and `emr_track.import` both refuse to write a track that already exists in the target db, regardless of `override` - that flag only ever covered *shadowing* a track held in another db:

```cpp
if (g_db->track(trackname) && (g_db->track_info(trackname)->db_id == db_id))
    verror("Track %s already exists", trackname.c_str());
```

So a caller wanting to rebuild a track in place has no option but to `emr_track.rm()` it first. That is what `wis_cohort.build()` / `wis_computed_track.build()` in wiser.epi do, and it leaves the track **absent for the entire rebuild** - every reader in that window fails. It is the root of the "rebuild a cohort and everything depending on it breaks for a few minutes" problem in wiser.

## What

- `override = TRUE` now also means "rewrite this track in its own db". Cross-db behaviour is unchanged.
- Every track write is staged to `<track>.nrtrack.tmp.<pid>` and renamed into place. `rename(2)` replaces the target atomically, so a concurrent reader sees either the complete previous track or the complete new one - never a missing or partial file.
- `emr_track.import` already staged to a `.tmp` file, but called `unlink(target)` before the move, which reopened exactly the window the staging was there to close. `rename` replaces the target by itself, so the unlink just goes away.
- The staging name carries the pid so two writers of the same track cannot corrupt each other's staging file, and it is removed if serialization or the rename throws.

A track is a single file (`<db>/<name>.nrtrack`), so the rename really is atomic - no directory tree to swap.

Callers can now drop the rm-then-rebuild dance entirely and pass `override = TRUE`.

## Tests

New `tests/testthat/test-track.overwrite.R`: same-db rewrite via both entry points, still errors without `override`, data actually replaced, and no staging files left behind.

Heads up on the existing suite: it is flaky independently of this change. Three runs of unmodified `master` produced three different failure sets (7, 8 and 9 failing tests, with `filters work on an overridden track`, `read_only is also overridden when overriding a track` and `emr_track.addto works with file` coming and going). Two runs of this branch produce 597 tests with the same 8 failures as one of those baseline runs, and the 3 new tests pass. So no new failures are attributable here, but the suite is not a reliable per-test signal as it stands - probably worth a separate look, several of these tests share and mutate one on-disk db.

## Note on scope

`.vars` / attributes are still written separately after the track file, so a reader landing between the rename and the var write sees the new track with the old `spec`. That degrades to `wis_track_compiled()` returning FALSE (at worst a redundant rebuild), not an error, and two files cannot be swapped in a single atomic operation anyway.