### PR TITLE
Close four holes in the 2.7.0 locking mechanism

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: naryn
 Title: Native Access Medical Record Retriever for High Yield Analytics
-Version: 2.7.1
+Version: 2.7.2
 Authors@R: c(
     person("Misha", "Hoichman", , "misha@hoichman.com", role = "aut"),
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # naryn 2.7.2
 
-* Fixed three holes in the 2.7.0 locking mechanism: the per-track attributes file was still written in place (and `emr_track.attr.set` took no lock at all, so a concurrent set on another track could drop an attribute from the aggregate cache); a nested writer-lock acquire on the same path silently released the outer lock, because closing any fd on a file drops every `fcntl` lock the process holds on it; and a failed commit rename was discarded silently instead of raising an error.
+* Fixed four holes in the 2.7.0 locking mechanism, where readers stopped taking a lock and rely on writes being committed by `rename`:
+    * The per-track attributes file was still written in place, so a reader could observe it partial or empty. It is now staged and renamed like every other metadata write.
+    * `emr_track.attr.set` took no lock at all, while being a read-modify-write of both the per-track file and the db's aggregate attributes cache. Two setters on *different* tracks never contended, and the loser's attribute disappeared from the cache that fresh sessions read.
+    * A nested writer-lock acquire on the same path silently released the outer lock, because closing any fd on a file drops every `fcntl` lock the process holds on it. The helper is now reentrant.
+    * A failed commit rename was discarded silently instead of raising an error.
 * Directory scans no longer abort when a file disappears between `readdir` and `stat` - staged `.tmp` files and NFS silly-rename entries are transient and are now skipped.
 
 # naryn 2.7.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# naryn 2.7.2
+
+* Fixed three holes in the 2.7.0 locking mechanism: the per-track attributes file was still written in place (and `emr_track.attr.set` took no lock at all, so a concurrent set on another track could drop an attribute from the aggregate cache); a nested writer-lock acquire on the same path silently released the outer lock, because closing any fd on a file drops every `fcntl` lock the process holds on it; and a failed commit rename was discarded silently instead of raising an error.
+* Directory scans no longer abort when a file disappears between `readdir` and `stat` - staged `.tmp` files and NFS silly-rename entries are transient and are now skipped.
+
 # naryn 2.7.1
 
 * Merged the CRAN-portability fixes from 2.6.32-2.6.34 onto the new locking mechanism introduced in 2.7.0.

--- a/src/BufferedFile.cpp
+++ b/src/BufferedFile.cpp
@@ -87,14 +87,22 @@ int BufferedFile::close()
 		m_fp = NULL;
         
         // ATOMIC COMMIT
+        // Callers report the failure with strerror(errno), so errno has to survive the cleanup
+        // unlink below: POSIX leaves it unspecified after a *successful* call, so a working
+        // unlink is free to overwrite the error the caller is about to print, and a failing one
+        // certainly does.
         if (m_is_atomic && !m_temp_filename.empty()) {
             if (retv == 0) {
                 if (rename(m_temp_filename.c_str(), m_real_filename.c_str()) != 0) {
+                    int commit_errno = errno;
                     unlink(m_temp_filename.c_str());
+                    errno = commit_errno;
                     retv = -1;
                 }
             } else {
+                int commit_errno = errno;
                 unlink(m_temp_filename.c_str());
+                errno = commit_errno;
             }
             m_temp_filename.clear();
         }

--- a/src/BufferedFile.h
+++ b/src/BufferedFile.h
@@ -53,7 +53,9 @@ public:
 
 	bool opened() const { return m_fp != NULL; }
 
-	const std::string &file_name() const { return m_filename; }
+	// The file the caller asked for. On an atomic write that is the destination, not the staging
+	// path - error messages naming a .tmp.<host>.<pid> file help nobody.
+	const std::string &file_name() const { return m_is_atomic ? m_real_filename : m_filename; }
 
 	int64_t file_size() const { return m_file_size; }
 

--- a/src/EMRDb.cpp
+++ b/src/EMRDb.cpp
@@ -198,8 +198,15 @@ void EMRDb::load_logical_tracks_from_disk() {
 
             snprintf(filename, sizeof(filename), "%s/%s", logical_tracks_dir().c_str(),
                     dirp->d_name);
-            if (stat(filename, &fs))
+            // A name can vanish between readdir and stat: metadata writes stage a
+            // <file>.tmp.<host>.<pid> in this directory and rename it away, and NFS leaves
+            // .nfsXXXX silly-rename entries that disappear when the last reader closes. Neither
+            // is ours to index, and neither is an error - skip and carry on.
+            if (stat(filename, &fs)) {
+                if (errno == ENOENT)
+                    continue;
                 verror("Failed to stat file %s: %s", filename, strerror(errno));
+            }
 
             // is it a normal file having file extension of a track?
             if (S_ISREG(fs.st_mode) &&
@@ -332,8 +339,10 @@ void EMRDb::update_logical_tracks_file() {
             verror("Error while writing file %s: %s\n", bf.file_name().c_str(),
                    strerror(errno));
 
-        // release lock
-        bf.close();
+        // close() commits the staged file with a rename. If that fails the update is thrown
+        // away and the old file stays, so it has to be reported like any other write error.
+        if (bf.close())
+            verror("Failed to commit file %s: %s", filename.c_str(), strerror(errno));
     }
     catch (...) {
         bf.discard();
@@ -755,11 +764,26 @@ int EMRDb::get_db_idx(const string& db_id) {
     
 }
 
-// Helper to acquire a persistent lock file for writing
+// Helper to acquire a persistent lock file for writing.
+//
+// Reentrancy matters here, and not for style reasons: fcntl locks are per (process, file), not
+// per fd, and closing ANY fd on a locked file drops every lock the process holds on it. So a
+// nested acquire/release of the same path - load_track() holds the track list lock and calls
+// load_track_list(), which on a missing or corrupt list calls create_track_list_file(), which
+// locks the same path - would silently release the outer lock at the inner release, leaving the
+// rest of the outer critical section unprotected. We therefore hand the nested caller -1
+// ("someone above you already holds this") and let release_writer_lock ignore it; every call
+// site already treats -1 as "nothing to release".
 int EMRDb::acquire_writer_lock(const string &base_filename) {
     string lock_path = base_filename + ".lock";
-    
-    // Open/Create the lock file
+
+    if (m_held_lock_paths.find(lock_path) != m_held_lock_paths.end()) {
+        return -1; // already held further up this call stack
+    }
+
+    // 0666 here lands as 0660 in practice: Naryn's ctor sets umask(07), so the lock file gets the
+    // same group-writable mode as every other file naryn writes. That is deliberate - anyone with
+    // write access to the db already has to be in its group, so no extra widening is warranted.
     int fd = open(lock_path.c_str(), O_RDWR | O_CREAT, 0666);
     if (fd == -1) {
          verror("Failed to open lock file %s: %s", lock_path.c_str(), strerror(errno));
@@ -768,7 +792,7 @@ int EMRDb::acquire_writer_lock(const string &base_filename) {
     struct flock fl;
     memset(&fl, 0, sizeof(fl));
     fl.l_type = F_WRLCK; // Exclusive Write Lock
-    
+
     // Blocking wait for lock
     while (fcntl(fd, F_SETLKW, &fl) == -1) {
         if (errno != EINTR) {
@@ -776,14 +800,23 @@ int EMRDb::acquire_writer_lock(const string &base_filename) {
             verror("Failed to lock %s: %s", lock_path.c_str(), strerror(errno));
         }
     }
-    
+
+    m_held_lock_paths.insert(lock_path);
+    m_held_lock_fds[fd] = lock_path;
     return fd;
 }
 
 void EMRDb::release_writer_lock(int fd) {
-    if (fd != -1) {
-        close(fd); // Closing fd releases the fcntl lock automatically
+    if (fd == -1) {
+        return; // nested acquire: the outer holder owns the lock and will release it
     }
+
+    auto ifd = m_held_lock_fds.find(fd);
+    if (ifd != m_held_lock_fds.end()) {
+        m_held_lock_paths.erase(ifd->second);
+        m_held_lock_fds.erase(ifd);
+    }
+    close(fd); // Closing fd releases the fcntl lock automatically
 }
 
 void EMRDb::validate_rootdirs(const vector<string>& rootdirs){
@@ -978,10 +1011,14 @@ void EMRDb::create_track_list_file(string db_id, BufferedFile *_pbf) {
 
             snprintf(filename, sizeof(filename), "%s/%s", db_id.c_str(), dirp->d_name);
 
+            // See the logical-tracks scan: a staging or NFS silly-rename entry can disappear
+            // between readdir and stat. Not an error, just not something to index.
             if (stat(filename, &fs)){
+                if (errno == ENOENT)
+                    continue;
                 verror("Failed to stat file %s: %s", filename, strerror(errno));
             }
-                
+
             if (S_ISREG(fs.st_mode) && (uint64_t)len > TRACK_FILE_EXT.size() &&
                 !strncmp(dirp->d_name + len - TRACK_FILE_EXT.size(),
                          TRACK_FILE_EXT.c_str(), TRACK_FILE_EXT.size())) {
@@ -1000,7 +1037,9 @@ void EMRDb::create_track_list_file(string db_id, BufferedFile *_pbf) {
         // write the results into track list file
         update_track_list_file(track_list, db_id, *pbf);
 
-        if (!_pbf) pbf->close();
+        if (!_pbf && pbf->close())
+            verror("Failed to commit file %s: %s",
+                   track_list_filename(db_id).c_str(), strerror(errno));
     }
     catch (...) {
         if (dir){
@@ -1274,7 +1313,9 @@ void EMRDb::load_track(const char *track_name, const string& db_id){
              verror("Failed to open file %s: %s", track_list_filename(db_id).c_str(), strerror(errno));
         }
         update_track_list_file(m_tracks, db_id, bf);
-        bf.close();
+        if (bf.close())
+            verror("Failed to commit file %s: %s",
+                   track_list_filename(db_id).c_str(), strerror(errno));
     }
     catch (...) {
         bf.discard();
@@ -1347,7 +1388,9 @@ void EMRDb::unload_track(const char *track_name, const bool& overridden, const b
                  verror("Failed to open file %s: %s", track_list_filename(db_id).c_str(), strerror(errno));
             }
             update_track_list_file(m_tracks, db_id, bf);
-            bf.close();
+            if (bf.close())
+                verror("Failed to commit file %s: %s",
+                       track_list_filename(db_id).c_str(), strerror(errno));
         }
     }
     catch (...) {
@@ -1427,30 +1470,45 @@ void EMRDb::set_track_attr(const char *trackname, const char *attr,
         track_attrs_fname = track_attrs_filename(db_id, trackname);
     }
     
-    TrackAttrs track_attrs = EMRTrack::load_attrs(trackname, track_attrs_fname.c_str());
+    // Setting one attribute is a read-modify-write of two files: the per-track attrs file, and
+    // the db's aggregate .attrs cache that every reader is actually served from. Both have to sit
+    // in ONE critical section, and it has to be the aggregate's lock - a per-track lock would let
+    // two setters on *different* tracks run concurrently, each rewrite the whole aggregate from
+    // its own view, and the loser's attribute would vanish from every fresh session while its
+    // per-track file still held the value. Lock the aggregate for the whole function; the nested
+    // acquire inside update_tracks_attrs_file below sees we already hold it and no-ops.
+    int lock_fd = acquire_writer_lock(tracks_attrs_filename(db_id));
 
-    if (val) {
-        track_attrs[attr] = val;
+    try {
+        TrackAttrs track_attrs = EMRTrack::load_attrs(trackname, track_attrs_fname.c_str());
+
+        if (val) {
+            track_attrs[attr] = val;
+        }
+        else {
+            track_attrs.erase(attr);
+        }
+
+        EMRTrack::save_attrs(trackname, track_attrs_fname.c_str(), track_attrs);
+
+        load_tracks_attrs(db_id);
+
+        if (track_attrs.empty()){
+            m_track2attrs[db_id].erase(trackname);
+        }
+        else {
+            m_track2attrs[db_id][trackname] = track_attrs;
+        }
+
+        if (update){
+            update_tracks_attrs_file(db_id);
+        }
     }
-    else {
-        track_attrs.erase(attr);
-    }    
-
-    EMRTrack::save_attrs(trackname, track_attrs_fname.c_str(), track_attrs);
-
-    load_tracks_attrs(db_id);
-
-    if (track_attrs.empty()){
-        m_track2attrs[db_id].erase(trackname);
+    catch (...) {
+        release_writer_lock(lock_fd);
+        throw;
     }
-    else {
-        m_track2attrs[db_id][trackname] = track_attrs;
-    }
-
-    if (update){
-        update_tracks_attrs_file(db_id);
-    }
-    
+    release_writer_lock(lock_fd);
 }
 
 void EMRDb::load_tracks_attrs(string db_id)
@@ -1632,9 +1690,11 @@ void EMRDb::update_tracks_attrs_file(string db_id) {
         if (bf.error()){
             verror("Error while writing file %s: %s\n", bf.file_name().c_str(), strerror(errno));
         }
-        bf.close();
+        if (bf.close())
+            verror("Failed to commit file %s: %s", filename.c_str(), strerror(errno));
     }
     catch (...) {
+        bf.discard();
         release_writer_lock(lock_fd);
         throw;
     }

--- a/src/EMRDb.h
+++ b/src/EMRDb.h
@@ -2,6 +2,7 @@
 #define EMRDB_H_INCLUDED
 
 #include <map>
+#include <set>
 #include <sys/mman.h>
 #include <unordered_map>
 #include <unordered_set>
@@ -205,9 +206,16 @@ protected:
     string logical_tracks_filename() const { return m_rootdirs[0] + "/" + LOGICAL_TRACKS_FILENAME;}
     string ids_filename() const { return m_rootdirs[0] + "/" + IDS_FILENAME; }
 
-    // Helper to acquire a persistent lock file for writing
+    // Helper to acquire a persistent lock file for writing. Reentrant: a nested acquire of a
+    // path this process already holds returns -1 and releases nothing, because closing any fd
+    // on a file drops all of the process's fcntl locks on it.
     int acquire_writer_lock(const string &base_filename);
     void release_writer_lock(int fd);
+
+    // Writer locks currently held by this process, by lock-file path and by fd. Not guarded by
+    // a mutex: naryn runs single-threaded under R.
+    std::set<string> m_held_lock_paths;
+    std::map<int, string> m_held_lock_fds;
 
     // make sure that rootdirs are readable
     void validate_rootdirs(const vector<string> &rootdirs);

--- a/src/EMRTrack.cpp
+++ b/src/EMRTrack.cpp
@@ -236,7 +236,9 @@ void EMRTrack::save_attrs(const char *track, const char *filename, const TrackAt
 
 	BufferedFile bfile;
 
-	if (bfile.open(filename, "wb"))
+	// Staged and renamed into place, like every other metadata write: readers of this file take
+	// no lock, so an in-place truncate-and-rewrite would expose a partial (or empty) attrs file.
+	if (bfile.open(filename, "wb", false, true))
 		TGLError<EMRTrack>(FILE_ERROR, "Failed to write attributes file %s: %s", filename, strerror(errno));
 
 	for (TrackAttrs::const_iterator iattr = attrs.begin(); iattr != attrs.end(); ++iattr) {
@@ -246,6 +248,12 @@ void EMRTrack::save_attrs(const char *track, const char *filename, const TrackAt
 		}
 	}
 
-	if (bfile.error())
+	if (bfile.error()) {
+		bfile.discard();
+		TGLError<EMRTrack>(FILE_ERROR, "Failed to write attributes file %s: %s", filename, strerror(errno));
+	}
+
+	// close() performs the rename; a failure there means the update was thrown away.
+	if (bfile.close())
 		TGLError<EMRTrack>(FILE_ERROR, "Failed to write attributes file %s: %s", filename, strerror(errno));
 }

--- a/tests/testthat/test-locking.R
+++ b/tests/testthat/test-locking.R
@@ -1,0 +1,53 @@
+# Guards for the 2.7.0 locking holes. Readers take no lock and rely on every write being
+# committed by a rename, so most of the failure modes here need two processes inside the same
+# few microseconds and are not reachable from a test. These two are.
+
+fresh_db <- function(name) {
+    db <- file.path(tempdir(), name)
+    unlink(db, recursive = TRUE)
+    dir.create(db)
+    emr_db.connect(db)
+    df <- data.frame(id = 1, time = 1, value = 1)
+    emr_track.import("ta", space = "global", categorical = FALSE, src = df)
+    emr_track.import("tb", space = "global", categorical = FALSE, src = df)
+    db
+}
+
+test_that("a failed commit raises instead of reporting success", {
+    db <- fresh_db("lock_db_failed_commit")
+    emr_track.attr.set("ta", "description", "first")
+
+    # Every metadata write stages to a temporary file and commits it with a rename. Putting a
+    # directory where the target belongs is the one way to fail that rename, and only that
+    # rename, without root: staging still succeeds, and rename(2) refuses to replace a
+    # directory. The commit failure used to be dropped on the floor - the update was discarded,
+    # the old file stayed, and R saw success.
+    agg <- file.path(db, ".attrs")
+    unlink(agg)
+    dir.create(agg)
+    withr::defer(unlink(agg, recursive = TRUE))
+
+    expect_error(emr_track.attr.set("ta", "description", "second"), "Failed to commit")
+    # The rename's errno, not whatever the cleanup unlink left behind.
+    expect_error(emr_track.attr.set("ta", "description", "second"), "Is a directory")
+})
+
+test_that("a write through a missing track list keeps its lock and rebuilds the list", {
+    db <- fresh_db("lock_db_missing_list")
+
+    # emr_track.import holds the track-list lock and then reaches create_track_list_file, which
+    # asks for the same lock. That nested acquire used to open and close a second fd on the file,
+    # and closing any fd drops every fcntl lock the process holds on it - so the rest of the
+    # write ran unprotected. The nested acquire now no-ops instead.
+    # The dropped lock is silent on its own, so this only asserts the path still works: it
+    # catches a recursive acquire that blocks or fails outright, not the missing exclusion.
+    unlink(file.path(db, ".naryn"))
+
+    df <- data.frame(id = 2, time = 2, value = 2)
+    emr_track.import("tc", space = "global", categorical = FALSE, src = df, override = TRUE)
+
+    expect_true(file.exists(file.path(db, ".naryn")))
+    expect_true(emr_track.exists("tc"))
+    emr_db.reload()
+    expect_true(all(c("ta", "tb", "tc") %in% emr_track.ls()))
+})


### PR DESCRIPTION
2.7.0 replaced fcntl read locks with staged writes committed by `rename`, so readers take no lock at all. Four paths did not hold up their end of that. Found by review of the same code on the stale `dev`-lineage branch (see the note at the bottom).

## What was wrong

**The per-track attributes file was still written in place.** `EMRTrack::save_attrs` opened the real `.attrs` file `"wb"`, truncating it, so a reader - which takes no lock - could observe a partial or empty file. Now staged and renamed like every other metadata write.

**`emr_track.attr.set` took no lock at all**, while being a read-modify-write of *two* files: the per-track `.attrs`, and the db's aggregate `.attrs` cache, which is what `get_tracks_attrs` actually serves from. Two setters on **different** tracks never contended, each rewrote the whole aggregate from its own view of `m_track2attrs`, and the loser's attribute vanished from every fresh session while its per-track file still held the value - so `emr_db.reload()` "fixed" it, which is about the worst symptom to debug. Now holds the aggregate's lock across the whole function, `update_tracks_attrs_file` included.

**A nested `acquire_writer_lock` on the same path silently released the outer lock.** fcntl locks are per (process, file), and closing *any* fd on a locked file drops every lock the process holds on it. `load_track` / `unload_track` hold the track-list lock and call `load_track_list`, which on a missing or corrupt list calls `create_track_list_file`, which locks the same path - the inner release then unlocked the outer critical section, and the rest of the function ran unprotected. The helper is now reentrant: a nested acquire returns `-1` and releases nothing. Every call site already treated `-1` as "nothing to release", so no call-site churn.

**A failed commit was silent.** `BufferedFile::close()` returns -1 when the rename fails, but every call site ignored it - on ENOSPC or a permissions problem the update was discarded, the old file stayed, and R saw success. Now checked at all five sites, and `update_tracks_attrs_file` gained the `bf.discard()` its siblings already had.

## Also

The two `readdir`+`stat` scans `verror` on any name they cannot stat. That was nearly unreachable before 2.7.0; now every metadata commit stages a `<file>.tmp.<host>.<pid>` in a scanned directory and renames it away, and NFS leaves `.nfsXXXX` silly-rename entries that disappear when the last reader closes. A concurrent `emr_db.reload()` would abort with `Failed to stat file ...tmp.node17.4821`. ENOENT is now skipped.

`file_name()` reports the destination rather than the staging path, so write errors name a file the user recognises instead of `.tmp.<host>.<pid>`.

## Testing

Builds clean. Functional check covering each fix passes: attrs read-modify-write keeps both attributes, attrs on two different tracks both survive a reload (the aggregate-cache bug above), no staging files left behind, and `emr_track.import` succeeds through the missing-track-list path that used to drop the outer lock.

The existing suite is not a usable per-test signal - five runs across patched and unpatched builds gave 1291-1453 tests with 5-7 failures and 1-12 errors, varying run to run, with the same cascade appearing on unpatched builds. The consistent core on every run is the three `test-x_multiple_db.R` override failures, present with and without this change. Worth its own look; several tests share and mutate one on-disk db.

## Note on branches

`dev` is at 2.6.31 and 8 commits behind `master`, having never received 2.7.0 or the CRAN-portability fixes. tanaylab/naryn#131, which introduced this locking mechanism, targets `dev` - but its branch was already merged into `master` in 1ca4e20 back in May, so its content is live as 2.7.0 while the PR still reads as open. Its CI now fails on `Rf_findVar` being dropped from the R API, which `master` fixed in 104521c (#133) and `dev` never got. That PR wants closing and `dev` wants fast-forwarding to `master`.

Version collision to note: tanaylab/naryn#134 also bumps to 2.7.2, so whichever of the two lands second needs 2.7.3.